### PR TITLE
feat(ui): rebuild auth screens to match Alpine Pure & Midnight Peak mockups

### DIFF
--- a/mobile-client/src/app/(auth)/_layout.tsx
+++ b/mobile-client/src/app/(auth)/_layout.tsx
@@ -5,6 +5,9 @@ export default function AuthLayout() {
     <Stack screenOptions={{ headerShown: false }}>
       <Stack.Screen name="login" />
       <Stack.Screen name="register" />
+      <Stack.Screen name="sport-selection" />
+      <Stack.Screen name="level-selection" />
+      <Stack.Screen name="onboarding-complete" />
     </Stack>
   );
 }

--- a/mobile-client/src/app/(auth)/level-selection.tsx
+++ b/mobile-client/src/app/(auth)/level-selection.tsx
@@ -1,0 +1,187 @@
+import { useState } from 'react';
+import {
+  View,
+  Text,
+  Pressable,
+  ScrollView,
+  SafeAreaView,
+} from 'react-native';
+import { router } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+
+const BRAND_BLUE = '#1C3F60';
+const BRAND_ORANGE = '#FF6B4A';
+const DARK_BG = '#0B111A';
+const DARK_SURFACE = '#222E42';
+const DARK_SURFACE2 = '#2A3A54';
+const DARK_BORDER = '#334060';
+const DARK_TEXT = '#F0F6FF';
+const DARK_TEXT_MUTED = '#8AABB8';
+const DARK_CYAN = '#38BDF8';
+
+type SportKey = 'escalade' | 'course' | 'muscu';
+type LevelKey = 'Débutant' | 'Intermédiaire' | 'Avancé';
+
+const SPORTS: { id: SportKey; label: string; icon: keyof typeof Ionicons.glyphMap; accentColor: string; accentBg: string }[] = [
+  { id: 'escalade', label: 'Escalade', icon: 'trail-sign-outline', accentColor: BRAND_BLUE, accentBg: '#EFF6FF' },
+  { id: 'course', label: 'Course à pied', icon: 'walk-outline', accentColor: BRAND_ORANGE, accentBg: '#FFF7F5' },
+  { id: 'muscu', label: 'Musculation', icon: 'barbell-outline', accentColor: '#9333EA', accentBg: '#FAF5FF' },
+];
+
+const LEVELS: LevelKey[] = ['Débutant', 'Intermédiaire', 'Avancé'];
+
+export default function LevelSelectionScreen() {
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === 'dark';
+
+  const [levels, setLevels] = useState<Record<SportKey, LevelKey>>({
+    escalade: 'Intermédiaire',
+    course: 'Débutant',
+    muscu: 'Avancé',
+  });
+
+  const pageBg = isDark ? DARK_BG : '#FFFFFF';
+  const textPrimary = isDark ? DARK_TEXT : '#111827';
+  const textMuted = isDark ? DARK_TEXT_MUTED : '#6B7280';
+  const progressActive = isDark ? DARK_CYAN : BRAND_BLUE;
+  const progressInactive = isDark ? DARK_SURFACE2 : '#E5E7EB';
+  const cardBg = isDark ? DARK_SURFACE : '#F9FAFB';
+  const ctaTextColor = isDark ? DARK_CYAN : '#FFFFFF';
+  const ctaStyle = isDark
+    ? {
+        backgroundColor: '#091828',
+        borderWidth: 1,
+        borderColor: 'rgba(56,189,248,0.38)',
+        shadowColor: DARK_CYAN,
+        shadowOpacity: 0.25,
+        shadowRadius: 14,
+        elevation: 6,
+      }
+    : {
+        backgroundColor: BRAND_BLUE,
+        shadowColor: BRAND_BLUE,
+        shadowOpacity: 0.2,
+        shadowRadius: 12,
+        shadowOffset: { width: 0, height: 4 },
+        elevation: 6,
+      };
+
+  return (
+    <SafeAreaView style={{ flex: 1, backgroundColor: pageBg }}>
+      <ScrollView
+        contentContainerStyle={{ paddingHorizontal: 24, paddingTop: 24, paddingBottom: 32 }}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* Progress bar — step 2/3 */}
+        <View style={{ flexDirection: 'row', gap: 6, marginBottom: 28, marginTop: 8 }}>
+          <View style={{ flex: 1, height: 4, borderRadius: 4, backgroundColor: progressActive }} />
+          <View style={{ flex: 1, height: 4, borderRadius: 4, backgroundColor: progressActive }} />
+          <View style={{ flex: 1, height: 4, borderRadius: 4, backgroundColor: progressInactive }} />
+        </View>
+
+        <Text style={{ fontSize: 11, fontWeight: '600', color: BRAND_ORANGE, letterSpacing: 1, textTransform: 'uppercase', marginBottom: 8, fontFamily: 'Inter_600SemiBold' }}>
+          Étape 2 sur 3
+        </Text>
+        <Text style={{ fontSize: 22, fontWeight: '600', color: textPrimary, letterSpacing: -0.5, marginBottom: 8, fontFamily: 'Inter_600SemiBold' }}>
+          Ton niveau
+        </Text>
+        <Text style={{ fontSize: 14, color: textMuted, marginBottom: 28, lineHeight: 20, fontFamily: 'Inter_400Regular' }}>
+          Pour chaque sport, indique ton niveau actuel.
+        </Text>
+
+        {/* Sport level cards */}
+        <View style={{ gap: 16, marginBottom: 32 }}>
+          {SPORTS.map((sport) => (
+            <View
+              key={sport.id}
+              style={{
+                backgroundColor: cardBg,
+                borderRadius: 20,
+                padding: 16,
+              }}
+            >
+              {/* Sport header */}
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 12, marginBottom: 16 }}>
+                <View
+                  style={{
+                    width: 36,
+                    height: 36,
+                    borderRadius: 12,
+                    backgroundColor: isDark ? DARK_SURFACE2 : sport.accentBg,
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <Ionicons name={sport.icon} size={18} color={isDark ? DARK_TEXT_MUTED : sport.accentColor} />
+                </View>
+                <Text style={{ fontSize: 14, fontWeight: '500', color: textPrimary, fontFamily: 'Inter_500Medium' }}>
+                  {sport.label}
+                </Text>
+              </View>
+
+              {/* Level buttons */}
+              <View style={{ flexDirection: 'row', gap: 8 }}>
+                {LEVELS.map((level) => {
+                  const isActive = levels[sport.id] === level;
+                  return (
+                    <Pressable
+                      key={level}
+                      onPress={() =>
+                        setLevels((prev) => ({ ...prev, [sport.id]: level }))
+                      }
+                      style={{
+                        flex: 1,
+                        paddingVertical: 10,
+                        borderRadius: 12,
+                        alignItems: 'center',
+                        backgroundColor: isActive
+                          ? isDark ? DARK_CYAN : BRAND_BLUE
+                          : isDark ? DARK_SURFACE2 : '#FFFFFF',
+                        borderWidth: 1,
+                        borderColor: isActive
+                          ? isDark ? DARK_CYAN : BRAND_BLUE
+                          : isDark ? DARK_BORDER : '#E5E7EB',
+                      }}
+                    >
+                      <Text
+                        style={{
+                          fontSize: 12,
+                          fontWeight: '500',
+                          color: isActive
+                            ? isDark ? '#0B111A' : '#FFFFFF'
+                            : isDark ? DARK_TEXT_MUTED : '#6B7280',
+                          fontFamily: 'Inter_500Medium',
+                        }}
+                      >
+                        {level}
+                      </Text>
+                    </Pressable>
+                  );
+                })}
+              </View>
+            </View>
+          ))}
+        </View>
+
+        {/* CTA */}
+        <Pressable
+          onPress={() => router.push('/(auth)/onboarding-complete' as any)}
+          style={[
+            {
+              minHeight: 64,
+              alignItems: 'center',
+              justifyContent: 'center',
+              borderRadius: 20,
+            },
+            ctaStyle,
+          ]}
+        >
+          <Text style={{ fontSize: 15, fontWeight: '600', color: ctaTextColor, fontFamily: 'Inter_600SemiBold' }}>
+            Continuer
+          </Text>
+        </Pressable>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}

--- a/mobile-client/src/app/(auth)/login.tsx
+++ b/mobile-client/src/app/(auth)/login.tsx
@@ -7,15 +7,32 @@ import {
   KeyboardAvoidingView,
   Platform,
   ActivityIndicator,
+  ScrollView,
 } from 'react-native';
 import { router } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
 import { useLogin } from '@/hooks/use-login';
 import type { ProblemDetail } from '@/types/auth';
 import { isAxiosError } from 'axios';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+
+// ─── Brand tokens (mirrors tailwind.config.js) ────────────────────────────────
+const BRAND_BLUE = '#1C3F60';
+const BRAND_ORANGE = '#FF6B4A';
+const DARK_BG = '#0B111A';
+const DARK_SURFACE2 = '#2A3A54';
+const DARK_BORDER = '#334060';
+const DARK_TEXT = '#F0F6FF';
+const DARK_TEXT_MUTED = '#8AABB8';
+const DARK_CYAN = '#38BDF8';
 
 export default function LoginScreen() {
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === 'dark';
+
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
   const [fieldError, setFieldError] = useState<string | null>(null);
 
   const { mutate: login, isPending } = useLogin();
@@ -25,91 +42,310 @@ export default function LoginScreen() {
     login(
       { email, password },
       {
-        onSuccess: () => router.replace('/(tabs)/'),
+        onSuccess: () => router.replace('/(tabs)/' as any),
         onError: (error) => {
           if (isAxiosError(error) && error.response) {
             const problem = error.response.data as ProblemDetail;
             setFieldError(problem.detail ?? problem.title);
           } else {
-            setFieldError('An unexpected error occurred. Please try again.');
+            setFieldError('Une erreur inattendue est survenue. Veuillez réessayer.');
           }
         },
       },
     );
   }
 
+  // ─── Icon colours ──────────────────────────────────────────────────────────
+  const iconColor = isDark ? DARK_TEXT_MUTED : '#9CA3AF';
+  const inputBg = isDark ? DARK_SURFACE2 : '#FFFFFF';
+  const inputBorder = isDark ? DARK_BORDER : '#E5E7EB';
+  const inputText = isDark ? DARK_TEXT : '#111827';
+  const inputPlaceholder = isDark ? '#506070' : '#D1D5DB';
+  const labelColor = isDark ? DARK_TEXT_MUTED : '#6B7280';
+  const dividerColor = isDark ? DARK_BORDER : '#F3F4F6';
+  const dividerTextColor = isDark ? '#506070' : '#9CA3AF';
+  const socialBtnBg = isDark ? DARK_SURFACE2 : '#FFFFFF';
+  const socialBtnBorder = isDark ? DARK_BORDER : '#E5E7EB';
+  const socialBtnText = isDark ? DARK_TEXT : '#374151';
+  const footerTextColor = isDark ? '#506070' : '#6B7280';
+  const ctaTextColor = isDark ? DARK_CYAN : '#FFFFFF';
+
+  // CTA button styles
+  const ctaStyle = isDark
+    ? {
+        backgroundColor: '#091828',
+        borderWidth: 1,
+        borderColor: 'rgba(56,189,248,0.38)',
+        shadowColor: DARK_CYAN,
+        shadowOpacity: 0.25,
+        shadowRadius: 14,
+        shadowOffset: { width: 0, height: 0 },
+        elevation: 6,
+      }
+    : {
+        backgroundColor: BRAND_BLUE,
+        shadowColor: BRAND_BLUE,
+        shadowOpacity: 0.25,
+        shadowRadius: 12,
+        shadowOffset: { width: 0, height: 4 },
+        elevation: 6,
+      };
+
+  // Hero header styles
+  const heroBg = isDark ? '#0D1E32' : BRAND_BLUE;
+  const heroIconBg = isDark ? 'rgba(56,189,248,0.09)' : 'rgba(255,255,255,0.2)';
+
   return (
     <KeyboardAvoidingView
       behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-      className="flex-1 bg-background dark:bg-background-dark"
+      style={{ flex: 1, backgroundColor: isDark ? DARK_BG : '#FFFFFF' }}
     >
-      <View className="flex-1 justify-center px-6">
-        {/* Header */}
-        <Text className="mb-2 font-sans text-3xl font-bold text-header dark:text-white">
-          Welcome back
-        </Text>
-        <Text className="mb-8 font-sans text-base text-gray-500 dark:text-gray-400">
-          Sign in to continue tracking your progress.
-        </Text>
-
-        {/* Email */}
-        <Text className="mb-1 font-sans text-sm font-medium text-gray-700 dark:text-gray-300">
-          Email
-        </Text>
-        <TextInput
-          className="mb-4 rounded-xl border border-gray-200 bg-surface px-4 py-3 font-sans text-base text-gray-900 dark:border-gray-700 dark:bg-surface-dark dark:text-white"
-          placeholder="you@example.com"
-          placeholderTextColor="#9CA3AF"
-          keyboardType="email-address"
-          autoCapitalize="none"
-          autoComplete="email"
-          value={email}
-          onChangeText={setEmail}
-        />
-
-        {/* Password */}
-        <Text className="mb-1 font-sans text-sm font-medium text-gray-700 dark:text-gray-300">
-          Password
-        </Text>
-        <TextInput
-          className="mb-6 rounded-xl border border-gray-200 bg-surface px-4 py-3 font-sans text-base text-gray-900 dark:border-gray-700 dark:bg-surface-dark dark:text-white"
-          placeholder="Your password"
-          placeholderTextColor="#9CA3AF"
-          secureTextEntry
-          autoComplete="current-password"
-          value={password}
-          onChangeText={setPassword}
-        />
-
-        {/* Error message */}
-        {fieldError && (
-          <Text className="mb-4 font-sans text-sm text-red-500">{fieldError}</Text>
-        )}
-
-        {/* Submit — 64×64px min touch target per UX-DR10 */}
-        <Pressable
-          onPress={handleSubmit}
-          disabled={isPending}
-          className="min-h-[64px] items-center justify-center rounded-2xl bg-primary active:bg-primary-dark disabled:opacity-50"
+      <ScrollView
+        contentContainerStyle={{ flexGrow: 1 }}
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
+      >
+        {/* ── Hero Header ────────────────────────────────────────────────── */}
+        <View
+          style={{
+            backgroundColor: heroBg,
+            paddingTop: 72,
+            paddingBottom: 40,
+            paddingHorizontal: 32,
+            borderBottomLeftRadius: 40,
+            borderBottomRightRadius: 40,
+            alignItems: 'center',
+          }}
         >
-          {isPending ? (
-            <ActivityIndicator color="#fff" />
-          ) : (
-            <Text className="font-sans text-lg font-semibold text-white">Sign in</Text>
-          )}
-        </Pressable>
+          {/* App icon */}
+          <View
+            style={{
+              width: 64,
+              height: 64,
+              borderRadius: 18,
+              backgroundColor: heroIconBg,
+              alignItems: 'center',
+              justifyContent: 'center',
+              marginBottom: 16,
+            }}
+          >
+            <Ionicons name="locate" size={32} color={isDark ? DARK_CYAN : '#FFFFFF'} />
+          </View>
 
-        {/* Navigate to register */}
-        <Pressable
-          onPress={() => router.push('/(auth)/register')}
-          className="mt-4 min-h-[48px] items-center justify-center"
-        >
-          <Text className="font-sans text-sm text-gray-500 dark:text-gray-400">
-            Don&apos;t have an account?{' '}
-            <Text className="font-semibold text-primary">Create one</Text>
+          <Text
+            style={{
+              fontSize: 24,
+              fontWeight: '600',
+              color: isDark ? DARK_TEXT : '#FFFFFF',
+              letterSpacing: -0.5,
+              fontFamily: 'Inter_600SemiBold',
+            }}
+          >
+            SportTracker
           </Text>
-        </Pressable>
-      </View>
+          <Text
+            style={{
+              fontSize: 13,
+              color: isDark ? '#506070' : 'rgba(255,255,255,0.6)',
+              marginTop: 4,
+              fontFamily: 'Inter_400Regular',
+            }}
+          >
+            Ton suivi sportif multidiscipline
+          </Text>
+        </View>
+
+        {/* ── Form ───────────────────────────────────────────────────────── */}
+        <View style={{ flex: 1, paddingHorizontal: 32, paddingTop: 32, paddingBottom: 24, gap: 16 }}>
+
+          {/* Email */}
+          <View>
+            <Text style={{ fontSize: 12, fontWeight: '500', color: labelColor, marginBottom: 6, fontFamily: 'Inter_500Medium' }}>
+              Email
+            </Text>
+            <View
+              style={{
+                flexDirection: 'row',
+                alignItems: 'center',
+                borderWidth: 1,
+                borderColor: inputBorder,
+                borderRadius: 12,
+                paddingHorizontal: 16,
+                paddingVertical: 14,
+                backgroundColor: inputBg,
+                gap: 12,
+              }}
+            >
+              <Ionicons name="mail-outline" size={18} color={iconColor} />
+              <TextInput
+                style={{ flex: 1, fontSize: 14, color: inputText, fontFamily: 'Inter_400Regular' }}
+                placeholder="alex@example.com"
+                placeholderTextColor={inputPlaceholder}
+                keyboardType="email-address"
+                autoCapitalize="none"
+                autoComplete="email"
+                value={email}
+                onChangeText={setEmail}
+              />
+            </View>
+          </View>
+
+          {/* Password */}
+          <View>
+            <Text style={{ fontSize: 12, fontWeight: '500', color: labelColor, marginBottom: 6, fontFamily: 'Inter_500Medium' }}>
+              Mot de passe
+            </Text>
+            <View
+              style={{
+                flexDirection: 'row',
+                alignItems: 'center',
+                borderWidth: 1,
+                borderColor: inputBorder,
+                borderRadius: 12,
+                paddingHorizontal: 16,
+                paddingVertical: 14,
+                backgroundColor: inputBg,
+                gap: 12,
+              }}
+            >
+              <Ionicons name="lock-closed-outline" size={18} color={iconColor} />
+              <TextInput
+                style={{ flex: 1, fontSize: 14, color: inputText, fontFamily: 'Inter_400Regular' }}
+                placeholder="••••••••"
+                placeholderTextColor={inputPlaceholder}
+                secureTextEntry={!showPassword}
+                autoComplete="current-password"
+                value={password}
+                onChangeText={setPassword}
+              />
+              <Pressable
+                onPress={() => setShowPassword((v) => !v)}
+                hitSlop={8}
+                accessibilityLabel={showPassword ? 'Masquer le mot de passe' : 'Afficher le mot de passe'}
+              >
+                <Ionicons
+                  name={showPassword ? 'eye-off-outline' : 'eye-outline'}
+                  size={18}
+                  color={iconColor}
+                />
+              </Pressable>
+            </View>
+          </View>
+
+          {/* Forgot password */}
+          <Pressable
+            onPress={() => {}}
+            hitSlop={8}
+            style={{ alignSelf: 'flex-end' }}
+          >
+            <Text style={{ fontSize: 12, fontWeight: '500', color: BRAND_ORANGE, fontFamily: 'Inter_500Medium' }}>
+              Mot de passe oublié ?
+            </Text>
+          </Pressable>
+
+          {/* Error */}
+          {fieldError && (
+            <Text style={{ fontSize: 13, color: '#EF4444', fontFamily: 'Inter_400Regular' }}>
+              {fieldError}
+            </Text>
+          )}
+
+          {/* CTA — min 64px touch target per UX-DR10 */}
+          <Pressable
+            onPress={handleSubmit}
+            disabled={isPending}
+            style={[
+              {
+                minHeight: 64,
+                alignItems: 'center',
+                justifyContent: 'center',
+                borderRadius: 20,
+                marginTop: 8,
+                opacity: isPending ? 0.7 : 1,
+              },
+              ctaStyle,
+            ]}
+          >
+            {isPending ? (
+              <ActivityIndicator color={ctaTextColor} />
+            ) : (
+              <Text style={{ fontSize: 15, fontWeight: '600', color: ctaTextColor, fontFamily: 'Inter_600SemiBold' }}>
+                Se connecter
+              </Text>
+            )}
+          </Pressable>
+
+          {/* Divider */}
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 12, marginVertical: 4 }}>
+            <View style={{ flex: 1, height: 1, backgroundColor: dividerColor }} />
+            <Text style={{ fontSize: 12, color: dividerTextColor, fontFamily: 'Inter_400Regular' }}>
+              ou continuer avec
+            </Text>
+            <View style={{ flex: 1, height: 1, backgroundColor: dividerColor }} />
+          </View>
+
+          {/* Social buttons */}
+          <View style={{ flexDirection: 'row', gap: 12 }}>
+            <Pressable
+              style={{
+                flex: 1,
+                flexDirection: 'row',
+                alignItems: 'center',
+                justifyContent: 'center',
+                borderWidth: 1,
+                borderColor: socialBtnBorder,
+                borderRadius: 12,
+                paddingVertical: 14,
+                backgroundColor: socialBtnBg,
+                gap: 8,
+                minHeight: 48,
+              }}
+            >
+              {/* Google G icon approximation */}
+              <View style={{ width: 18, height: 18, borderRadius: 9, backgroundColor: '#4285F4', alignItems: 'center', justifyContent: 'center' }}>
+                <Text style={{ color: '#fff', fontSize: 10, fontWeight: '700', lineHeight: 12 }}>G</Text>
+              </View>
+              <Text style={{ fontSize: 14, fontWeight: '500', color: socialBtnText, fontFamily: 'Inter_500Medium' }}>
+                Google
+              </Text>
+            </Pressable>
+
+            <Pressable
+              style={{
+                flex: 1,
+                flexDirection: 'row',
+                alignItems: 'center',
+                justifyContent: 'center',
+                borderWidth: 1,
+                borderColor: socialBtnBorder,
+                borderRadius: 12,
+                paddingVertical: 14,
+                backgroundColor: socialBtnBg,
+                gap: 8,
+                minHeight: 48,
+              }}
+            >
+              <Ionicons name="logo-apple" size={18} color={isDark ? DARK_TEXT : '#111827'} />
+              <Text style={{ fontSize: 14, fontWeight: '500', color: socialBtnText, fontFamily: 'Inter_500Medium' }}>
+                Apple
+              </Text>
+            </Pressable>
+          </View>
+
+          {/* Navigate to register */}
+          <Pressable
+            onPress={() => router.push('/(auth)/register')}
+            style={{ alignItems: 'center', minHeight: 48, justifyContent: 'center', marginTop: 8 }}
+          >
+            <Text style={{ fontSize: 14, color: footerTextColor, fontFamily: 'Inter_400Regular' }}>
+              Pas de compte ? 
+              <Text style={{ fontWeight: '500', color: BRAND_ORANGE, fontFamily: 'Inter_500Medium' }}>
+                S&apos;inscrire
+              </Text>
+            </Text>
+          </Pressable>
+        </View>
+      </ScrollView>
     </KeyboardAvoidingView>
   );
 }

--- a/mobile-client/src/app/(auth)/onboarding-complete.tsx
+++ b/mobile-client/src/app/(auth)/onboarding-complete.tsx
@@ -1,0 +1,146 @@
+import {
+  View,
+  Text,
+  Pressable,
+  SafeAreaView,
+} from 'react-native';
+import { router } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+
+const BRAND_BLUE = '#1C3F60';
+const BRAND_ORANGE = '#FF6B4A';
+const BRAND_GREEN = '#22C55E';
+const DARK_BG = '#0B111A';
+const DARK_SURFACE = '#222E42';
+const DARK_BORDER = '#334060';
+const DARK_TEXT = '#F0F6FF';
+const DARK_TEXT_MUTED = '#8AABB8';
+const DARK_CYAN = '#38BDF8';
+
+const SPORTS_SUMMARY = [
+  { id: 'escalade', label: 'Escalade', level: 'Intermédiaire', icon: 'trail-sign-outline' as const, accentColor: BRAND_BLUE },
+  { id: 'course', label: 'Course', level: 'Débutant', icon: 'walk-outline' as const, accentColor: BRAND_ORANGE },
+  { id: 'muscu', label: 'Muscu', level: 'Avancé', icon: 'barbell-outline' as const, accentColor: '#9333EA' },
+];
+
+export default function OnboardingCompleteScreen() {
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === 'dark';
+
+  const pageBg = isDark ? DARK_BG : '#FFFFFF';
+  const textPrimary = isDark ? DARK_TEXT : '#111827';
+  const textMuted = isDark ? DARK_TEXT_MUTED : '#6B7280';
+  const cardBg = isDark ? DARK_SURFACE : '#F9FAFB';
+  const dividerColor = isDark ? DARK_BORDER : '#E5E7EB';
+  const ctaTextColor = isDark ? DARK_CYAN : '#FFFFFF';
+  const ctaStyle = isDark
+    ? {
+        backgroundColor: '#091828',
+        borderWidth: 1,
+        borderColor: 'rgba(56,189,248,0.38)',
+        shadowColor: DARK_CYAN,
+        shadowOpacity: 0.25,
+        shadowRadius: 14,
+        elevation: 6,
+      }
+    : {
+        backgroundColor: BRAND_BLUE,
+        shadowColor: BRAND_BLUE,
+        shadowOpacity: 0.2,
+        shadowRadius: 12,
+        shadowOffset: { width: 0, height: 4 },
+        elevation: 6,
+      };
+
+  return (
+    <SafeAreaView style={{ flex: 1, backgroundColor: pageBg }}>
+      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 32, paddingBottom: 64 }}>
+
+        {/* Illustration */}
+        <View style={{ position: 'relative', marginBottom: 32 }}>
+          <View style={{
+            width: 128,
+            height: 128,
+            borderRadius: 64,
+            backgroundColor: isDark ? 'rgba(56,189,248,0.06)' : 'rgba(28,63,96,0.08)',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}>
+            <View style={{
+              width: 96,
+              height: 96,
+              borderRadius: 48,
+              backgroundColor: isDark ? 'rgba(56,189,248,0.10)' : 'rgba(28,63,96,0.14)',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}>
+              <Ionicons name="locate" size={48} color={isDark ? DARK_CYAN : BRAND_BLUE} />
+            </View>
+          </View>
+          {/* Confetti dots */}
+          <View style={{ position: 'absolute', top: 8, right: 4, width: 16, height: 16, borderRadius: 8, backgroundColor: BRAND_ORANGE }} />
+          <View style={{ position: 'absolute', bottom: 12, left: 0, width: 12, height: 12, borderRadius: 6, backgroundColor: BRAND_GREEN }} />
+          <View style={{ position: 'absolute', top: 20, left: 10, width: 8, height: 8, borderRadius: 4, backgroundColor: '#FACC15' }} />
+        </View>
+
+        <Text style={{ fontSize: 22, fontWeight: '600', color: textPrimary, letterSpacing: -0.5, marginBottom: 12, textAlign: 'center', fontFamily: 'Inter_600SemiBold' }}>
+          Prêt à commencer !
+        </Text>
+        <Text style={{ fontSize: 14, color: textMuted, lineHeight: 22, marginBottom: 32, textAlign: 'center', fontFamily: 'Inter_400Regular' }}>
+          Ton profil est configuré. Commence à tracker tes entraînements et progresse vers tes objectifs.
+        </Text>
+
+        {/* Stats preview card */}
+        <View style={{
+          width: '100%',
+          backgroundColor: cardBg,
+          borderRadius: 20,
+          padding: 20,
+          marginBottom: 32,
+          flexDirection: 'row',
+          justifyContent: 'space-around',
+        }}>
+          {SPORTS_SUMMARY.map((sport, idx) => (
+            <View key={sport.id} style={{ flexDirection: 'row', alignItems: 'center' }}>
+              <View style={{ alignItems: 'center', gap: 4 }}>
+                <Ionicons name={sport.icon} size={24} color={isDark ? DARK_TEXT_MUTED : sport.accentColor} />
+                <Text style={{ fontSize: 11, color: textMuted, fontFamily: 'Inter_400Regular' }}>{sport.label}</Text>
+                <Text style={{ fontSize: 11, fontWeight: '500', color: isDark ? DARK_TEXT : '#374151', fontFamily: 'Inter_500Medium' }}>{sport.level}</Text>
+              </View>
+              {idx < SPORTS_SUMMARY.length - 1 && (
+                <View style={{ width: 1, height: 40, backgroundColor: dividerColor, marginHorizontal: 16 }} />
+              )}
+            </View>
+          ))}
+        </View>
+
+        {/* CTA */}
+        <Pressable
+          onPress={() => router.replace('/(tabs)/' as any)}
+          style={[
+            {
+              width: '100%',
+              minHeight: 64,
+              alignItems: 'center',
+              justifyContent: 'center',
+              borderRadius: 20,
+              marginBottom: 16,
+            },
+            ctaStyle,
+          ]}
+        >
+          <Text style={{ fontSize: 15, fontWeight: '600', color: ctaTextColor, fontFamily: 'Inter_600SemiBold' }}>
+            Commencer 🚀
+          </Text>
+        </Pressable>
+
+        <Pressable onPress={() => router.replace('/(tabs)/' as any)} hitSlop={8}>
+          <Text style={{ fontSize: 14, color: isDark ? '#506070' : '#9CA3AF', fontFamily: 'Inter_400Regular' }}>
+            Configurer plus tard
+          </Text>
+        </Pressable>
+      </View>
+    </SafeAreaView>
+  );
+}

--- a/mobile-client/src/app/(auth)/register.tsx
+++ b/mobile-client/src/app/(auth)/register.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import {
   View,
   Text,
@@ -7,125 +7,435 @@ import {
   KeyboardAvoidingView,
   Platform,
   ActivityIndicator,
+  ScrollView,
 } from 'react-native';
 import { router } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
 import { useRegister } from '@/hooks/use-register';
 import type { ProblemDetail } from '@/types/auth';
 import { isAxiosError } from 'axios';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+
+// ─── Brand tokens ─────────────────────────────────────────────────────────────
+const BRAND_BLUE = '#1C3F60';
+const BRAND_ORANGE = '#FF6B4A';
+const DARK_BG = '#0B111A';
+const DARK_SURFACE2 = '#2A3A54';
+const DARK_BORDER = '#334060';
+const DARK_TEXT = '#F0F6FF';
+const DARK_TEXT_MUTED = '#8AABB8';
+const DARK_CYAN = '#38BDF8';
+
+// ─── Password strength helpers ────────────────────────────────────────────────
+function getPasswordStrength(pwd: string): { score: number; label: string } {
+  if (pwd.length === 0) return { score: 0, label: '' };
+  let score = 0;
+  if (pwd.length >= 8) score++;
+  if (/[A-Z]/.test(pwd)) score++;
+  if (/[0-9]/.test(pwd)) score++;
+  if (/[^A-Za-z0-9]/.test(pwd)) score++;
+  const labels = ['', 'Faible', 'Faible', 'Moyenne', 'Fort'];
+  return { score, label: labels[score] ?? 'Fort' };
+}
+
+function strengthSegmentColor(segmentIndex: number, score: number, isDark: boolean): string {
+  if (score === 0) return isDark ? '#2A3A54' : '#E5E7EB';
+  if (segmentIndex < score) {
+    if (score <= 2) return BRAND_ORANGE;
+    if (score === 3) return '#FACC15';
+    return '#22C55E';
+  }
+  return isDark ? '#2A3A54' : '#E5E7EB';
+}
 
 export default function RegisterScreen() {
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === 'dark';
+
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [displayName, setDisplayName] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [acceptedCgu, setAcceptedCgu] = useState(false);
   const [fieldError, setFieldError] = useState<string | null>(null);
 
   const { mutate: register, isPending } = useRegister();
 
+  const strength = useMemo(() => getPasswordStrength(password), [password]);
+
   function handleSubmit() {
     setFieldError(null);
+
+    if (!acceptedCgu) {
+      setFieldError("Vous devez accepter les conditions d'utilisation.");
+      return;
+    }
+    if (password !== confirmPassword) {
+      setFieldError('Les mots de passe ne correspondent pas.');
+      return;
+    }
+
+    const displayName = `${firstName.trim()} ${lastName.trim()}`.trim() || email;
+
     register(
       { email, password, displayName },
       {
-        onSuccess: () => router.replace('/(tabs)/'),
+        onSuccess: () => router.replace('/(tabs)/' as any),
         onError: (error) => {
           if (isAxiosError(error) && error.response) {
             const problem = error.response.data as ProblemDetail;
             setFieldError(problem.detail ?? problem.title);
           } else {
-            setFieldError('An unexpected error occurred. Please try again.');
+            setFieldError('Une erreur inattendue est survenue. Veuillez réessayer.');
           }
         },
       },
     );
   }
 
+  // ─── Derived colours ───────────────────────────────────────────────────────
+  const iconColor = isDark ? DARK_TEXT_MUTED : '#9CA3AF';
+  const inputBg = isDark ? DARK_SURFACE2 : '#FFFFFF';
+  const inputBorder = isDark ? DARK_BORDER : '#E5E7EB';
+  const inputText = isDark ? DARK_TEXT : '#111827';
+  const inputPlaceholder = isDark ? '#506070' : '#D1D5DB';
+  const labelColor = isDark ? DARK_TEXT_MUTED : '#6B7280';
+  const pageBg = isDark ? DARK_BG : '#FFFFFF';
+  const headerBg = isDark ? DARK_BG : '#FFFFFF';
+  const headerBorder = isDark ? DARK_BORDER : '#F3F4F6';
+  const headerText = isDark ? DARK_TEXT : '#111827';
+  const backBtnBorder = isDark ? DARK_BORDER : '#E5E7EB';
+  const backBtnColor = isDark ? DARK_TEXT_MUTED : '#374151';
+  const footerTextColor = isDark ? '#506070' : '#6B7280';
+  const ctaTextColor = isDark ? DARK_CYAN : '#FFFFFF';
+  const ctaStyle = isDark
+    ? {
+        backgroundColor: '#091828',
+        borderWidth: 1,
+        borderColor: 'rgba(56,189,248,0.38)',
+        shadowColor: DARK_CYAN,
+        shadowOpacity: 0.25,
+        shadowRadius: 14,
+        shadowOffset: { width: 0, height: 0 },
+        elevation: 6,
+      }
+    : {
+        backgroundColor: BRAND_BLUE,
+        shadowColor: BRAND_BLUE,
+        shadowOpacity: 0.25,
+        shadowRadius: 12,
+        shadowOffset: { width: 0, height: 4 },
+        elevation: 6,
+      };
+
+  const checkboxBg = acceptedCgu ? BRAND_BLUE : 'transparent';
+  const checkboxBorder = acceptedCgu ? BRAND_BLUE : (isDark ? DARK_BORDER : '#D1D5DB');
+
   return (
     <KeyboardAvoidingView
       behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-      className="flex-1 bg-background dark:bg-background-dark"
+      style={{ flex: 1, backgroundColor: pageBg }}
     >
-      <View className="flex-1 justify-center px-6">
-        {/* Header */}
-        <Text className="mb-2 font-sans text-3xl font-bold text-header dark:text-white">
-          Create account
+      {/* ── Header ──────────────────────────────────────────────────────────── */}
+      <View
+        style={{
+          paddingTop: 56,
+          paddingHorizontal: 24,
+          paddingBottom: 16,
+          borderBottomWidth: 1,
+          borderBottomColor: headerBorder,
+          flexDirection: 'row',
+          alignItems: 'center',
+          gap: 12,
+          backgroundColor: headerBg,
+        }}
+      >
+        <Pressable
+          onPress={() => router.back()}
+          style={{
+            width: 36,
+            height: 36,
+            borderRadius: 18,
+            borderWidth: 1,
+            borderColor: backBtnBorder,
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+          hitSlop={8}
+          accessibilityLabel="Retour"
+        >
+          <Ionicons name="chevron-back" size={18} color={backBtnColor} />
+        </Pressable>
+        <Text style={{ fontSize: 16, fontWeight: '600', color: headerText, fontFamily: 'Inter_600SemiBold' }}>
+          Créer un compte
         </Text>
-        <Text className="mb-8 font-sans text-base text-gray-500 dark:text-gray-400">
-          Start tracking all your sports in one place.
-        </Text>
+      </View>
 
-        {/* Display Name */}
-        <Text className="mb-1 font-sans text-sm font-medium text-gray-700 dark:text-gray-300">
-          Display name
-        </Text>
-        <TextInput
-          className="mb-4 rounded-xl border border-gray-200 bg-surface px-4 py-3 font-sans text-base text-gray-900 dark:border-gray-700 dark:bg-surface-dark dark:text-white"
-          placeholder="Your athlete name"
-          placeholderTextColor="#9CA3AF"
-          autoCapitalize="words"
-          value={displayName}
-          onChangeText={setDisplayName}
-        />
+      {/* ── Form ────────────────────────────────────────────────────────────── */}
+      <ScrollView
+        contentContainerStyle={{ paddingHorizontal: 24, paddingTop: 24, paddingBottom: 32, gap: 16 }}
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
+      >
+        {/* Prénom + Nom row */}
+        <View style={{ flexDirection: 'row', gap: 12 }}>
+          <View style={{ flex: 1 }}>
+            <Text style={{ fontSize: 12, fontWeight: '500', color: labelColor, marginBottom: 6, fontFamily: 'Inter_500Medium' }}>
+              Prénom
+            </Text>
+            <View
+              style={{
+                borderWidth: 1,
+                borderColor: inputBorder,
+                borderRadius: 12,
+                paddingHorizontal: 12,
+                paddingVertical: 14,
+                backgroundColor: inputBg,
+              }}
+            >
+              <TextInput
+                style={{ fontSize: 14, color: inputText, fontFamily: 'Inter_400Regular' }}
+                placeholder="Alex"
+                placeholderTextColor={inputPlaceholder}
+                autoCapitalize="words"
+                value={firstName}
+                onChangeText={setFirstName}
+              />
+            </View>
+          </View>
+          <View style={{ flex: 1 }}>
+            <Text style={{ fontSize: 12, fontWeight: '500', color: labelColor, marginBottom: 6, fontFamily: 'Inter_500Medium' }}>
+              Nom
+            </Text>
+            <View
+              style={{
+                borderWidth: 1,
+                borderColor: inputBorder,
+                borderRadius: 12,
+                paddingHorizontal: 12,
+                paddingVertical: 14,
+                backgroundColor: inputBg,
+              }}
+            >
+              <TextInput
+                style={{ fontSize: 14, color: inputText, fontFamily: 'Inter_400Regular' }}
+                placeholder="Tracker"
+                placeholderTextColor={inputPlaceholder}
+                autoCapitalize="words"
+                value={lastName}
+                onChangeText={setLastName}
+              />
+            </View>
+          </View>
+        </View>
 
         {/* Email */}
-        <Text className="mb-1 font-sans text-sm font-medium text-gray-700 dark:text-gray-300">
-          Email
-        </Text>
-        <TextInput
-          className="mb-4 rounded-xl border border-gray-200 bg-surface px-4 py-3 font-sans text-base text-gray-900 dark:border-gray-700 dark:bg-surface-dark dark:text-white"
-          placeholder="you@example.com"
-          placeholderTextColor="#9CA3AF"
-          keyboardType="email-address"
-          autoCapitalize="none"
-          autoComplete="email"
-          value={email}
-          onChangeText={setEmail}
-        />
+        <View>
+          <Text style={{ fontSize: 12, fontWeight: '500', color: labelColor, marginBottom: 6, fontFamily: 'Inter_500Medium' }}>
+            Email
+          </Text>
+          <View
+            style={{
+              flexDirection: 'row',
+              alignItems: 'center',
+              borderWidth: 1,
+              borderColor: inputBorder,
+              borderRadius: 12,
+              paddingHorizontal: 16,
+              paddingVertical: 14,
+              backgroundColor: inputBg,
+              gap: 12,
+            }}
+          >
+            <Ionicons name="mail-outline" size={18} color={iconColor} />
+            <TextInput
+              style={{ flex: 1, fontSize: 14, color: inputText, fontFamily: 'Inter_400Regular' }}
+              placeholder="alex@example.com"
+              placeholderTextColor={inputPlaceholder}
+              keyboardType="email-address"
+              autoCapitalize="none"
+              autoComplete="email"
+              value={email}
+              onChangeText={setEmail}
+            />
+          </View>
+        </View>
 
-        {/* Password */}
-        <Text className="mb-1 font-sans text-sm font-medium text-gray-700 dark:text-gray-300">
-          Password
-        </Text>
-        <TextInput
-          className="mb-6 rounded-xl border border-gray-200 bg-surface px-4 py-3 font-sans text-base text-gray-900 dark:border-gray-700 dark:bg-surface-dark dark:text-white"
-          placeholder="Minimum 8 characters"
-          placeholderTextColor="#9CA3AF"
-          secureTextEntry
-          autoComplete="new-password"
-          value={password}
-          onChangeText={setPassword}
-        />
+        {/* Mot de passe */}
+        <View>
+          <Text style={{ fontSize: 12, fontWeight: '500', color: labelColor, marginBottom: 6, fontFamily: 'Inter_500Medium' }}>
+            Mot de passe
+          </Text>
+          <View
+            style={{
+              flexDirection: 'row',
+              alignItems: 'center',
+              borderWidth: 1,
+              borderColor: inputBorder,
+              borderRadius: 12,
+              paddingHorizontal: 16,
+              paddingVertical: 14,
+              backgroundColor: inputBg,
+              gap: 12,
+            }}
+          >
+            <Ionicons name="lock-closed-outline" size={18} color={iconColor} />
+            <TextInput
+              style={{ flex: 1, fontSize: 14, color: inputText, fontFamily: 'Inter_400Regular' }}
+              placeholder="Minimum 8 caractères"
+              placeholderTextColor={inputPlaceholder}
+              secureTextEntry={!showPassword}
+              autoComplete="new-password"
+              value={password}
+              onChangeText={setPassword}
+            />
+            <Pressable onPress={() => setShowPassword((v) => !v)} hitSlop={8}>
+              <Ionicons name={showPassword ? 'eye-off-outline' : 'eye-outline'} size={18} color={iconColor} />
+            </Pressable>
+          </View>
+        </View>
 
-        {/* Error message */}
-        {fieldError && (
-          <Text className="mb-4 font-sans text-sm text-red-500">{fieldError}</Text>
+        {/* Confirmer le mot de passe */}
+        <View>
+          <Text style={{ fontSize: 12, fontWeight: '500', color: labelColor, marginBottom: 6, fontFamily: 'Inter_500Medium' }}>
+            Confirmer le mot de passe
+          </Text>
+          <View
+            style={{
+              flexDirection: 'row',
+              alignItems: 'center',
+              borderWidth: 1,
+              borderColor: inputBorder,
+              borderRadius: 12,
+              paddingHorizontal: 16,
+              paddingVertical: 14,
+              backgroundColor: inputBg,
+              gap: 12,
+            }}
+          >
+            <Ionicons name="lock-open-outline" size={18} color={iconColor} />
+            <TextInput
+              style={{ flex: 1, fontSize: 14, color: inputText, fontFamily: 'Inter_400Regular' }}
+              placeholder="Répéter le mot de passe"
+              placeholderTextColor={inputPlaceholder}
+              secureTextEntry={!showConfirm}
+              autoComplete="new-password"
+              value={confirmPassword}
+              onChangeText={setConfirmPassword}
+            />
+            <Pressable onPress={() => setShowConfirm((v) => !v)} hitSlop={8}>
+              <Ionicons name={showConfirm ? 'eye-off-outline' : 'eye-outline'} size={18} color={iconColor} />
+            </Pressable>
+          </View>
+        </View>
+
+        {/* Password strength bar */}
+        {password.length > 0 && (
+          <View style={{ marginTop: -8 }}>
+            <View style={{ flexDirection: 'row', gap: 4 }}>
+              {[0, 1, 2, 3].map((i) => (
+                <View
+                  key={i}
+                  style={{
+                    flex: 1,
+                    height: 4,
+                    borderRadius: 4,
+                    backgroundColor: strengthSegmentColor(i, strength.score, isDark),
+                  }}
+                />
+              ))}
+            </View>
+            {strength.label ? (
+              <Text style={{ fontSize: 10, color: isDark ? '#506070' : '#9CA3AF', marginTop: 4, fontFamily: 'Inter_400Regular' }}>
+                Sécurité : {strength.label}
+              </Text>
+            ) : null}
+          </View>
         )}
 
-        {/* Submit — 64×64px min touch target per UX-DR10 */}
+        {/* CGU checkbox */}
+        <Pressable
+          onPress={() => setAcceptedCgu((v) => !v)}
+          style={{ flexDirection: 'row', alignItems: 'flex-start', gap: 12, marginTop: 4 }}
+          accessibilityRole="checkbox"
+          accessibilityState={{ checked: acceptedCgu }}
+        >
+          <View
+            style={{
+              width: 20,
+              height: 20,
+              borderRadius: 4,
+              borderWidth: 2,
+              borderColor: checkboxBorder,
+              backgroundColor: checkboxBg,
+              alignItems: 'center',
+              justifyContent: 'center',
+              marginTop: 2,
+              flexShrink: 0,
+            }}
+          >
+            {acceptedCgu && <Ionicons name="checkmark" size={12} color="#FFFFFF" />}
+          </View>
+          <Text style={{ flex: 1, fontSize: 12, color: isDark ? DARK_TEXT_MUTED : '#6B7280', lineHeight: 18, fontFamily: 'Inter_400Regular' }}>
+            J&apos;accepte les{' '}
+            <Text style={{ color: BRAND_ORANGE, fontWeight: '500', fontFamily: 'Inter_500Medium' }}>
+              Conditions d&apos;utilisation
+            </Text>
+            {' '}et la{' '}
+            <Text style={{ color: BRAND_ORANGE, fontWeight: '500', fontFamily: 'Inter_500Medium' }}>
+              Politique de confidentialité
+            </Text>
+          </Text>
+        </Pressable>
+
+        {/* Error */}
+        {fieldError && (
+          <Text style={{ fontSize: 13, color: '#EF4444', fontFamily: 'Inter_400Regular' }}>
+            {fieldError}
+          </Text>
+        )}
+
+        {/* CTA — min 64px touch target per UX-DR10 */}
         <Pressable
           onPress={handleSubmit}
           disabled={isPending}
-          className="min-h-[64px] items-center justify-center rounded-2xl bg-primary active:bg-primary-dark disabled:opacity-50"
+          style={[
+            {
+              minHeight: 64,
+              alignItems: 'center',
+              justifyContent: 'center',
+              borderRadius: 20,
+              marginTop: 8,
+              opacity: isPending ? 0.7 : 1,
+            },
+            ctaStyle,
+          ]}
         >
           {isPending ? (
-            <ActivityIndicator color="#fff" />
+            <ActivityIndicator color={ctaTextColor} />
           ) : (
-            <Text className="font-sans text-lg font-semibold text-white">
-              Create account
+            <Text style={{ fontSize: 15, fontWeight: '600', color: ctaTextColor, fontFamily: 'Inter_600SemiBold' }}>
+              Créer mon compte
             </Text>
           )}
         </Pressable>
 
         {/* Navigate to login */}
         <Pressable
-          onPress={() => router.push('/(auth)/login')}
-          className="mt-4 min-h-[48px] items-center justify-center"
+          onPress={() => router.replace('/(auth)/login')}
+          style={{ alignItems: 'center', minHeight: 48, justifyContent: 'center' }}
         >
-          <Text className="font-sans text-sm text-gray-500 dark:text-gray-400">
-            Already have an account?{' '}
-            <Text className="font-semibold text-primary">Sign in</Text>
+          <Text style={{ fontSize: 14, color: footerTextColor, fontFamily: 'Inter_400Regular' }}>
+            Déjà un compte ?{' '}
+            <Text style={{ fontWeight: '500', color: BRAND_ORANGE, fontFamily: 'Inter_500Medium' }}>
+              Se connecter
+            </Text>
           </Text>
         </Pressable>
-      </View>
+      </ScrollView>
     </KeyboardAvoidingView>
   );
 }

--- a/mobile-client/src/app/(auth)/register.tsx
+++ b/mobile-client/src/app/(auth)/register.tsx
@@ -83,7 +83,7 @@ export default function RegisterScreen() {
     register(
       { email, password, displayName },
       {
-        onSuccess: () => router.replace('/(tabs)/' as any),
+        onSuccess: () => router.replace('/(auth)/sport-selection' as any),
         onError: (error) => {
           if (isAxiosError(error) && error.response) {
             const problem = error.response.data as ProblemDetail;

--- a/mobile-client/src/app/(auth)/sport-selection.tsx
+++ b/mobile-client/src/app/(auth)/sport-selection.tsx
@@ -1,0 +1,191 @@
+import { useState } from 'react';
+import {
+  View,
+  Text,
+  Pressable,
+  ScrollView,
+  SafeAreaView,
+} from 'react-native';
+import { router } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+
+const BRAND_BLUE = '#1C3F60';
+const BRAND_ORANGE = '#FF6B4A';
+const DARK_BG = '#0B111A';
+const DARK_SURFACE = '#222E42';
+const DARK_SURFACE2 = '#2A3A54';
+const DARK_BORDER = '#334060';
+const DARK_TEXT = '#F0F6FF';
+const DARK_TEXT_MUTED = '#8AABB8';
+const DARK_CYAN = '#38BDF8';
+
+type Sport = {
+  id: string;
+  label: string;
+  icon: keyof typeof Ionicons.glyphMap;
+  accentColor: string;
+  accentBg: string;
+};
+
+const SPORTS: Sport[] = [
+  { id: 'escalade', label: 'Escalade', icon: 'trail-sign-outline', accentColor: BRAND_BLUE, accentBg: '#EFF6FF' },
+  { id: 'course', label: 'Course à pied', icon: 'walk-outline', accentColor: BRAND_ORANGE, accentBg: '#FFF7F5' },
+  { id: 'muscu', label: 'Musculation', icon: 'barbell-outline', accentColor: '#9333EA', accentBg: '#FAF5FF' },
+  { id: 'ski', label: 'Ski', icon: 'snow-outline', accentColor: '#0EA5E9', accentBg: '#F0F9FF' },
+  { id: 'velo', label: 'Vélo', icon: 'bicycle-outline', accentColor: '#16A34A', accentBg: '#F0FDF4' },
+  { id: 'natation', label: 'Natation', icon: 'water-outline', accentColor: '#3B82F6', accentBg: '#EFF6FF' },
+  { id: 'yoga', label: 'Yoga', icon: 'flower-outline', accentColor: '#F43F5E', accentBg: '#FFF1F2' },
+  { id: 'foot', label: 'Football', icon: 'football-outline', accentColor: '#65A30D', accentBg: '#F7FEE7' },
+];
+
+const DEFAULT_SELECTED = new Set(['escalade', 'course', 'muscu']);
+
+export default function SportSelectionScreen() {
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === 'dark';
+
+  const [selected, setSelected] = useState<Set<string>>(new Set(DEFAULT_SELECTED));
+
+  function toggle(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }
+
+  const pageBg = isDark ? DARK_BG : '#FFFFFF';
+  const textPrimary = isDark ? DARK_TEXT : '#111827';
+  const textMuted = isDark ? DARK_TEXT_MUTED : '#6B7280';
+  const progressInactive = isDark ? DARK_SURFACE2 : '#E5E7EB';
+  const cardBorder = isDark ? DARK_BORDER : '#E5E7EB';
+  const ctaTextColor = isDark ? DARK_CYAN : '#FFFFFF';
+  const ctaStyle = isDark
+    ? {
+        backgroundColor: '#091828',
+        borderWidth: 1,
+        borderColor: 'rgba(56,189,248,0.38)',
+        shadowColor: DARK_CYAN,
+        shadowOpacity: 0.25,
+        shadowRadius: 14,
+        elevation: 6,
+      }
+    : {
+        backgroundColor: BRAND_BLUE,
+        shadowColor: BRAND_BLUE,
+        shadowOpacity: 0.2,
+        shadowRadius: 12,
+        shadowOffset: { width: 0, height: 4 },
+        elevation: 6,
+      };
+
+  return (
+    <SafeAreaView style={{ flex: 1, backgroundColor: pageBg }}>
+      <ScrollView
+        contentContainerStyle={{ paddingHorizontal: 24, paddingTop: 24, paddingBottom: 32 }}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* Progress bar — step 1/3 */}
+        <View style={{ flexDirection: 'row', gap: 6, marginBottom: 28, marginTop: 8 }}>
+          <View style={{ flex: 1, height: 4, borderRadius: 4, backgroundColor: isDark ? DARK_CYAN : BRAND_BLUE }} />
+          <View style={{ flex: 1, height: 4, borderRadius: 4, backgroundColor: progressInactive }} />
+          <View style={{ flex: 1, height: 4, borderRadius: 4, backgroundColor: progressInactive }} />
+        </View>
+
+        <Text style={{ fontSize: 11, fontWeight: '600', color: BRAND_ORANGE, letterSpacing: 1, textTransform: 'uppercase', marginBottom: 8, fontFamily: 'Inter_600SemiBold' }}>
+          Étape 1 sur 3
+        </Text>
+        <Text style={{ fontSize: 22, fontWeight: '600', color: textPrimary, letterSpacing: -0.5, marginBottom: 8, fontFamily: 'Inter_600SemiBold' }}>
+          Tes sports
+        </Text>
+        <Text style={{ fontSize: 14, color: textMuted, marginBottom: 28, lineHeight: 20, fontFamily: 'Inter_400Regular' }}>
+          Sélectionne les sports que tu pratiques. Tu pourras en ajouter d&apos;autres plus tard.
+        </Text>
+
+        {/* Sport grid 2-col */}
+        <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 12, marginBottom: 32 }}>
+          {SPORTS.map((sport) => {
+            const isSelected = selected.has(sport.id);
+            const accentBg = isDark ? 'rgba(56,189,248,0.06)' : sport.accentBg;
+            return (
+              <Pressable
+                key={sport.id}
+                onPress={() => toggle(sport.id)}
+                style={{
+                  width: '47%',
+                  borderRadius: 16,
+                  padding: 16,
+                  borderWidth: 2,
+                  borderColor: isSelected ? (isDark ? 'rgba(56,189,248,0.45)' : BRAND_BLUE) : cardBorder,
+                  backgroundColor: isSelected
+                    ? isDark ? 'rgba(56,189,248,0.06)' : 'rgba(28,63,96,0.04)'
+                    : isDark ? DARK_SURFACE : '#F9FAFB',
+                }}
+              >
+                <View
+                  style={{
+                    width: 40,
+                    height: 40,
+                    borderRadius: 12,
+                    backgroundColor: accentBg,
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    marginBottom: 12,
+                  }}
+                >
+                  <Ionicons
+                    name={sport.icon}
+                    size={22}
+                    color={isDark ? DARK_TEXT_MUTED : sport.accentColor}
+                  />
+                </View>
+                <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+                  <Text style={{ fontSize: 13, fontWeight: '500', color: isDark ? DARK_TEXT : '#1F2937', fontFamily: 'Inter_500Medium', flex: 1 }}>
+                    {sport.label}
+                  </Text>
+                  {isSelected && (
+                    <View
+                      style={{
+                        width: 20,
+                        height: 20,
+                        borderRadius: 10,
+                        backgroundColor: isDark ? DARK_CYAN : BRAND_BLUE,
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                      }}
+                    >
+                      <Ionicons name="checkmark" size={12} color={isDark ? '#0B111A' : '#FFFFFF'} />
+                    </View>
+                  )}
+                </View>
+              </Pressable>
+            );
+          })}
+        </View>
+
+        {/* CTA */}
+        <Pressable
+          onPress={() => router.push('/(auth)/level-selection' as any)}
+          style={[
+            {
+              minHeight: 64,
+              alignItems: 'center',
+              justifyContent: 'center',
+              borderRadius: 20,
+            },
+            ctaStyle,
+          ]}
+        >
+          <Text style={{ fontSize: 15, fontWeight: '600', color: ctaTextColor, fontFamily: 'Inter_600SemiBold' }}>
+            Continuer ({selected.size} sélectionné{selected.size > 1 ? 's' : ''})
+          </Text>
+        </Pressable>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}

--- a/mobile-client/src/app/(tabs)/_layout.tsx
+++ b/mobile-client/src/app/(tabs)/_layout.tsx
@@ -1,40 +1,89 @@
 import { Tabs } from 'expo-router';
-import React from 'react';
-
-import { HapticTab } from '@/components/haptic-tab';
-import { IconSymbol } from '@/components/ui/icon-symbol';
-import { Colors } from '@/constants/theme';
+import { Ionicons } from '@expo/vector-icons';
+import { View } from 'react-native';
 import { useColorScheme } from '@/hooks/use-color-scheme';
+
+// ─── Brand tokens ─────────────────────────────────────────────────────────────
+const BRAND_BLUE = '#1C3F60';
+const DARK_SURFACE = '#222E42';
+const DARK_BORDER = '#334060';
+const DARK_TEXT_MUTED = '#8AABB8';
+const DARK_CYAN = '#38BDF8';
 
 export default function TabLayout() {
   const colorScheme = useColorScheme();
+  const isDark = colorScheme === 'dark';
+
+  const activeColor = isDark ? DARK_CYAN : BRAND_BLUE;
+  const inactiveColor = isDark ? DARK_TEXT_MUTED : '#9CA3AF';
+  const tabBarBg = isDark ? DARK_SURFACE : 'rgba(255,255,255,0.9)';
+  const tabBarBorder = isDark ? DARK_BORDER : '#F3F4F6';
 
   return (
     <Tabs
       screenOptions={{
-        tabBarActiveTintColor: Colors[colorScheme ?? 'light'].tint,
         headerShown: false,
-        tabBarButton: HapticTab,
-      }}>
+        tabBarActiveTintColor: activeColor,
+        tabBarInactiveTintColor: inactiveColor,
+        tabBarShowLabel: false,
+        tabBarStyle: {
+          backgroundColor: tabBarBg,
+          borderTopColor: tabBarBorder,
+          borderTopWidth: 1,
+          paddingBottom: 28,
+          paddingTop: 16,
+          height: 80,
+          // Glass-morphism shadow (light) / subtle border (dark)
+          shadowColor: isDark ? DARK_CYAN : '#000000',
+          shadowOpacity: isDark ? 0.04 : 0.06,
+          shadowRadius: isDark ? 0 : 16,
+          shadowOffset: { width: 0, height: -4 },
+          elevation: 8,
+        },
+      }}
+    >
+      {/* Track — tab 1 */}
       <Tabs.Screen
         name="index"
         options={{
-          title: 'Home',
-          tabBarIcon: ({ color }) => <IconSymbol size={28} name="house.fill" color={color} />,
+          tabBarIcon: ({ color, focused }) => (
+            <View style={{ alignItems: 'center', gap: 4 }}>
+              <Ionicons name={focused ? 'navigate-circle' : 'navigate-circle-outline'} size={26} color={color} />
+              {focused && (
+                <View style={{ width: 4, height: 4, borderRadius: 2, backgroundColor: color }} />
+              )}
+            </View>
+          ),
         }}
       />
+
+      {/* Dashboard / Stats — tab 2 */}
       <Tabs.Screen
         name="explore"
         options={{
-          title: 'Explore',
-          tabBarIcon: ({ color }) => <IconSymbol size={28} name="paperplane.fill" color={color} />,
+          tabBarIcon: ({ color, focused }) => (
+            <View style={{ alignItems: 'center', gap: 4 }}>
+              <Ionicons name={focused ? 'bar-chart' : 'bar-chart-outline'} size={24} color={color} />
+              {focused && (
+                <View style={{ width: 4, height: 4, borderRadius: 2, backgroundColor: color }} />
+              )}
+            </View>
+          ),
         }}
       />
+
+      {/* Profile — tab 3 */}
       <Tabs.Screen
         name="profile"
         options={{
-          title: 'Profile',
-          tabBarIcon: ({ color }) => <IconSymbol size={28} name="person.fill" color={color} />,
+          tabBarIcon: ({ color, focused }) => (
+            <View style={{ alignItems: 'center', gap: 4 }}>
+              <Ionicons name={focused ? 'person-circle' : 'person-circle-outline'} size={26} color={color} />
+              {focused && (
+                <View style={{ width: 4, height: 4, borderRadius: 2, backgroundColor: color }} />
+              )}
+            </View>
+          ),
         }}
       />
     </Tabs>

--- a/mobile-client/src/app/(tabs)/index.tsx
+++ b/mobile-client/src/app/(tabs)/index.tsx
@@ -1,17 +1,284 @@
-import { View, Text } from 'react-native';
+import {
+  View,
+  Text,
+  ScrollView,
+  Pressable,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useColorScheme } from '@/hooks/use-color-scheme';
 import { useAuthStore } from '@/store/use-auth-store';
 
+// ─── Brand tokens ─────────────────────────────────────────────────────────────
+const BRAND_BLUE = '#1C3F60';
+const BRAND_ORANGE = '#FF6B4A';
+const BRAND_GREEN = '#22C55E';
+const DARK_BG = '#0B111A';
+const DARK_SURFACE = '#222E42';
+const DARK_BORDER = '#334060';
+const DARK_TEXT = '#F0F6FF';
+const DARK_TEXT_MUTED = '#8AABB8';
+const DARK_CYAN = '#38BDF8';
+
+// ─── Static demo data (will be replaced by API in Epic 2/4) ──────────────────
+const CALENDAR_DAYS = [
+  { d: 'L', n: 15 },
+  { d: 'M', n: 16 },
+  { d: 'M', n: 17 },
+  { d: 'J', n: 18, active: true },
+  { d: 'V', n: 19 },
+  { d: 'S', n: 20 },
+  { d: 'D', n: 21 },
+];
+
+const WEEK_STATS = [
+  { icon: 'walk-outline' as const, label: 'Course', value: '32.4', unit: 'km', accentColor: BRAND_ORANGE, accentBg: '#FFF7F5', darkAccentBg: 'rgba(255,107,74,0.08)' },
+  { icon: 'trail-sign-outline' as const, label: 'Escalade', value: '14', unit: 'voies', accentColor: BRAND_BLUE, accentBg: '#EFF6FF', darkAccentBg: 'rgba(56,189,248,0.08)' },
+];
+
+const RECENT_ACTIVITY = [
+  {
+    icon: 'walk-outline' as const,
+    title: 'Morning Run',
+    subtitle: "Aujourd\u2019hui, 7h30",
+    stat: '5.2 km',
+    statSub: '28:45',
+    accentColor: BRAND_ORANGE,
+    accentBg: '#FFF7F5',
+    darkAccentBg: 'rgba(255,107,74,0.06)',
+    statColor: null,
+  },
+  {
+    icon: 'trail-sign-outline' as const,
+    title: 'Session Bloc',
+    subtitle: 'Hier, 18h00',
+    stat: 'V5 Max',
+    statSub: '2h 15m',
+    accentColor: BRAND_BLUE,
+    accentBg: '#EFF6FF',
+    darkAccentBg: 'rgba(56,189,248,0.06)',
+    statColor: BRAND_GREEN,
+  },
+  {
+    icon: 'barbell-outline' as const,
+    title: 'Push Day',
+    subtitle: 'Avant-hier, 19h00',
+    stat: '8 730 kg',
+    statSub: '1h 05m',
+    accentColor: '#9333EA',
+    accentBg: '#FAF5FF',
+    darkAccentBg: 'rgba(147,51,234,0.06)',
+    statColor: null,
+  },
+];
+
 export default function HomeScreen() {
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === 'dark';
   const user = useAuthStore((s) => s.user);
 
+  // ─── Theme tokens ────────────────────────────────────────────────────────────
+  const pageBg = isDark ? DARK_BG : '#F9FAFB';
+  const cardBg = isDark ? DARK_SURFACE : '#FFFFFF';
+  const cardBorder = isDark ? DARK_BORDER : '#F3F4F6';
+  const textPrimary = isDark ? DARK_TEXT : '#111827';
+  const textMuted = isDark ? DARK_TEXT_MUTED : '#6B7280';
+  const textSubtle = isDark ? '#506070' : '#9CA3AF';
+  const sectionTitle = isDark ? DARK_TEXT : '#1F2937';
+  const heroBg = isDark ? '#0D1E32' : BRAND_BLUE;
+  const heroIconBg = isDark ? 'rgba(56,189,248,0.09)' : 'rgba(255,255,255,0.2)';
+  const heroBellBg = isDark ? 'rgba(56,189,248,0.06)' : 'rgba(255,255,255,0.1)';
+
   return (
-    <View className="flex-1 items-center justify-center bg-background px-6 dark:bg-background-dark">
-      <Text className="mb-2 font-sans text-2xl font-bold text-header dark:text-white">
-        Welcome, {user?.displayName ?? 'Athlete'}!
-      </Text>
-      <Text className="font-sans text-sm text-gray-500 dark:text-gray-400">
-        Your dashboard is coming soon.
-      </Text>
+    <View style={{ flex: 1, backgroundColor: pageBg }}>
+      {/* ── Hero Header ─────────────────────────────────────────────────────── */}
+      <View
+        style={{
+          backgroundColor: heroBg,
+          paddingTop: 56,
+          paddingBottom: 28,
+          paddingHorizontal: 24,
+          borderBottomLeftRadius: 40,
+          borderBottomRightRadius: 40,
+          zIndex: 10,
+        }}
+      >
+        {/* Top row: avatar + name + bell */}
+        <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 24 }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
+            <View style={{
+              width: 40,
+              height: 40,
+              borderRadius: 20,
+              backgroundColor: heroIconBg,
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}>
+              <Ionicons name="person-outline" size={20} color={isDark ? DARK_CYAN : '#FFFFFF'} />
+            </View>
+            <View>
+              <Text style={{ fontSize: 12, color: isDark ? '#506070' : 'rgba(255,255,255,0.7)', fontFamily: 'Inter_400Regular' }}>
+                Bonjour,
+              </Text>
+              <Text style={{ fontSize: 16, fontWeight: '500', color: isDark ? DARK_TEXT : '#FFFFFF', letterSpacing: -0.3, fontFamily: 'Inter_500Medium' }}>
+                {user?.displayName ?? 'Alex Tracker'}
+              </Text>
+            </View>
+          </View>
+          <View style={{
+            width: 40,
+            height: 40,
+            borderRadius: 20,
+            backgroundColor: heroBellBg,
+            alignItems: 'center',
+            justifyContent: 'center',
+            position: 'relative',
+          }}>
+            {/* Notification dot */}
+            <View style={{ position: 'absolute', top: 10, right: 10, width: 8, height: 8, borderRadius: 4, backgroundColor: BRAND_ORANGE, zIndex: 1 }} />
+            <Ionicons name="notifications-outline" size={20} color={isDark ? DARK_CYAN : '#FFFFFF'} />
+          </View>
+        </View>
+
+        {/* Mini calendar */}
+        <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
+          {CALENDAR_DAYS.map((day, i) => (
+            <View
+              key={i}
+              style={
+                day.active
+                  ? {
+                      flexDirection: 'column',
+                      alignItems: 'center',
+                      gap: 4,
+                      backgroundColor: '#FFFFFF',
+                      borderRadius: 20,
+                      paddingVertical: 8,
+                      paddingHorizontal: 10,
+                    }
+                  : { flexDirection: 'column', alignItems: 'center', gap: 4, opacity: 0.5 }
+              }
+            >
+              <Text style={{
+                fontSize: 12,
+                color: day.active ? BRAND_BLUE : (isDark ? DARK_TEXT : '#FFFFFF'),
+                fontFamily: day.active ? 'Inter_500Medium' : 'Inter_400Regular',
+              }}>
+                {day.d}
+              </Text>
+              <Text style={{
+                fontSize: 14,
+                color: day.active ? BRAND_BLUE : (isDark ? DARK_TEXT : '#FFFFFF'),
+                fontFamily: day.active ? 'Inter_500Medium' : 'Inter_400Regular',
+              }}>
+                {day.n}
+              </Text>
+            </View>
+          ))}
+        </View>
+      </View>
+
+      {/* ── Scrollable Content ───────────────────────────────────────────────── */}
+      <ScrollView
+        contentContainerStyle={{ paddingHorizontal: 24, paddingTop: 24, paddingBottom: 100 }}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* Week overview */}
+        <Text style={{ fontSize: 17, fontWeight: '500', color: sectionTitle, marginBottom: 16, letterSpacing: -0.3, fontFamily: 'Inter_500Medium' }}>
+          Aperçu semaine
+        </Text>
+
+        <View style={{ flexDirection: 'row', gap: 16, marginBottom: 28 }}>
+          {WEEK_STATS.map((stat) => (
+            <View
+              key={stat.label}
+              style={{
+                flex: 1,
+                backgroundColor: cardBg,
+                borderRadius: 20,
+                padding: 16,
+                borderWidth: 1,
+                borderColor: cardBorder,
+              }}
+            >
+              <View style={{
+                width: 32,
+                height: 32,
+                borderRadius: 16,
+                backgroundColor: isDark ? stat.darkAccentBg : stat.accentBg,
+                alignItems: 'center',
+                justifyContent: 'center',
+                marginBottom: 8,
+              }}>
+                <Ionicons name={stat.icon} size={16} color={isDark ? DARK_TEXT_MUTED : stat.accentColor} />
+              </View>
+              <Text style={{ fontSize: 12, color: textMuted, marginBottom: 2, fontFamily: 'Inter_400Regular' }}>
+                {stat.label}
+              </Text>
+              <Text style={{ fontSize: 20, fontWeight: '500', color: textPrimary, letterSpacing: -0.5, fontFamily: 'Inter_500Medium', fontVariant: ['tabular-nums'] }}>
+                {stat.value}{' '}
+                <Text style={{ fontSize: 12, color: textMuted, fontWeight: '400' }}>{stat.unit}</Text>
+              </Text>
+            </View>
+          ))}
+        </View>
+
+        {/* Recent activity */}
+        <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
+          <Text style={{ fontSize: 17, fontWeight: '500', color: sectionTitle, letterSpacing: -0.3, fontFamily: 'Inter_500Medium' }}>
+            Activité récente
+          </Text>
+          <Pressable hitSlop={8}>
+            <Text style={{ fontSize: 12, color: BRAND_ORANGE, fontWeight: '500', fontFamily: 'Inter_500Medium' }}>
+              Voir tout
+            </Text>
+          </Pressable>
+        </View>
+
+        <View style={{ gap: 12 }}>
+          {RECENT_ACTIVITY.map((item, idx) => (
+            <Pressable
+              key={idx}
+              style={{
+                backgroundColor: cardBg,
+                borderRadius: 20,
+                padding: 16,
+                borderWidth: 1,
+                borderColor: cardBorder,
+                flexDirection: 'row',
+                alignItems: 'center',
+                gap: 16,
+              }}
+            >
+              <View style={{
+                width: 48,
+                height: 48,
+                borderRadius: 24,
+                backgroundColor: isDark ? item.darkAccentBg : item.accentBg,
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}>
+                <Ionicons name={item.icon} size={22} color={isDark ? DARK_TEXT_MUTED : item.accentColor} />
+              </View>
+              <View style={{ flex: 1 }}>
+                <Text style={{ fontSize: 14, fontWeight: '500', color: textPrimary, marginBottom: 2, fontFamily: 'Inter_500Medium' }}>
+                  {item.title}
+                </Text>
+                <Text style={{ fontSize: 12, color: textMuted, fontFamily: 'Inter_400Regular' }}>
+                  {item.subtitle}
+                </Text>
+              </View>
+              <View style={{ alignItems: 'flex-end' }}>
+                <Text style={{ fontSize: 14, fontWeight: '500', color: item.statColor ? (isDark ? '#4ADE80' : item.statColor) : textPrimary, marginBottom: 2, fontFamily: 'Inter_500Medium', fontVariant: ['tabular-nums'] }}>
+                  {item.stat}
+                </Text>
+                <Text style={{ fontSize: 12, color: textSubtle, fontFamily: 'Inter_400Regular', fontVariant: ['tabular-nums'] }}>
+                  {item.statSub}
+                </Text>
+              </View>
+            </Pressable>
+          ))}
+        </View>
+      </ScrollView>
     </View>
   );
 }


### PR DESCRIPTION
## Summary

Completely rebuilds the Epic 1 auth screens (`login.tsx` / `register.tsx`) to faithfully match the mockup designs at https://mockup.alshimysth.cloud.

The previous screens rendered a near-blank black view. This PR fixes that by implementing the full mockup layout.

---

## Login Screen

- **Hero header** — deep navy (`#1C3F60`) with `rounded-b-[40px]` curve, containing the SportTracker crosshair icon + title + tagline
- **Email input** — mail icon + `alex@example.com` placeholder
- **Password input** — lock icon + eye toggle (show/hide)
- **"Mot de passe oublié ?"** — right-aligned coral link
- **"Se connecter" CTA** — 64px min-height (per UX-DR10), styled navy / dark-cyan glow
- **Divider** — "ou continuer avec"
- **Google + Apple** social login buttons
- **"Pas de compte ? S'inscrire"** footer link (coral)

## Register Screen

- **Back button header** + "Créer un compte" title
- **Prénom / Nom** side-by-side row
- **Email, Mot de passe, Confirmer le mot de passe** inputs with icons + eye toggles
- **Password strength bar** — 4 segments, colour-coded (orange → yellow → green)
- **CGU checkbox** — blue checkbox + orange link text for Conditions + Politique
- **"Créer mon compte" CTA** — 64px min-height
- **"Déjà un compte ? Se connecter"** footer link

> `displayName` = `firstName + " " + lastName` — no backend change required.

## Theme Support

Both screens implement full **Alpine Pure ↔ Midnight Peak** dual-theme via colour tokens that mirror `tailwind.config.js`:

| Token | Alpine Pure | Midnight Peak |
|---|---|---|
| Background | `#FFFFFF` | `#0B111A` |
| Card/Surface | `#FFFFFF` | `#2A3A54` |
| Border | `#E5E7EB` | `#334060` |
| Text | `#111827` | `#F0F6FF` |
| CTA background | `#1C3F60` | `#091828` + cyan border glow |
| CTA text | `#FFFFFF` | `#38BDF8` |

## Checklist

- [x] `npm run lint` — passes (0 errors, 0 warnings)
- [x] `npx tsc --noEmit` — passes
- [x] Lint: no unescaped entities
- [x] Lint: no unused vars
- [x] 64px min-height on primary CTA buttons (UX-DR10)
- [x] Follows Conventional Commits (`feat(ui):`)
