### PR TITLE
feat(epic2/story2.3): TabularMetricDisplay featured metrics panel (UX…

### DIFF
--- a/mobile-client/src/app/tracking/running.tsx
+++ b/mobile-client/src/app/tracking/running.tsx
@@ -16,34 +16,7 @@ import { useColorScheme } from '@/hooks/use-color-scheme';
 import { colors } from '@/theme/colors';
 import { useSportStore } from '@/store/use-sport-store';
 import { useRunningTracker } from '@/hooks/use-running-tracker';
-import { MetricTile } from '@/components/features/tracking/MetricTile';
-
-// ─── Formatting helpers ───────────────────────────────────────────────────────
-
-/** 1 240 m → "1.24" / 980 m → "980 m" */
-function formatDistance(meters: number): string {
-  if (meters < 1000) return `${Math.round(meters)} m`;
-  return (meters / 1000).toFixed(2);
-}
-
-function distanceUnit(meters: number): string {
-  return meters < 1000 ? '' : 'km';
-}
-
-/** 512 s → "08:32" */
-function formatDuration(secs: number): string {
-  const m = Math.floor(secs / 60);
-  const s = secs % 60;
-  return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
-}
-
-/** 330 s/km → "5'30"" */
-function formatPace(secsPerKm: number): string {
-  if (secsPerKm <= 0) return "--'--";
-  const m = Math.floor(secsPerKm / 60);
-  const s = Math.round(secsPerKm % 60);
-  return `${m}'${String(s).padStart(2, '0')}"`;
-}
+import { RunningMetricsDisplay } from '@/components/features/tracking/RunningMetricsDisplay';
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
@@ -165,38 +138,19 @@ export default function RunningScreen() {
         </Pressable>
       </View>
 
-      {/* ── 2. Metric bar — TabularMetricDisplay (UX spec) ────────────────── */}
-      <View
-        style={{
-          backgroundColor: cardBg,
-          flexDirection: 'row',
-          borderBottomWidth: 1,
-          borderBottomColor: cardBorder,
-        }}
-      >
-        <MetricTile
-          value={formatDistance(metrics.distanceMeters)}
-          label={distanceUnit(metrics.distanceMeters) || 'distance'}
-          valueColor={metricValue}
-          labelColor={metricLabel}
-          separator
-          borderColor={metricDivider}
-        />
-        <MetricTile
-          value={formatDuration(metrics.durationSeconds)}
-          label="durée"
-          valueColor={metricValue}
-          labelColor={metricLabel}
-          separator
-          borderColor={metricDivider}
-        />
-        <MetricTile
-          value={formatPace(metrics.paceSecsPerKm)}
-          label="allure /km"
-          valueColor={accent}
-          labelColor={metricLabel}
-        />
-      </View>
+      {/* ── 2. Featured metrics panel — TabularMetricDisplay (UX-DR4) ──────── */}
+      <RunningMetricsDisplay
+        distanceMeters={metrics.distanceMeters}
+        durationSeconds={metrics.durationSeconds}
+        paceSecsPerKm={metrics.paceSecsPerKm}
+        accentColor={accent}
+        valueColor={metricValue}
+        secondaryValueColor={metricValue}
+        labelColor={metricLabel}
+        dividerColor={metricDivider}
+        cardBg={cardBg}
+        cardBorder={cardBorder}
+      />
 
       {/* ── 3. Map + polyline ─────────────────────────────────────────────── */}
       <View style={{ flex: 1 }}>

--- a/mobile-client/src/components/features/tracking/RunningMetricsDisplay.tsx
+++ b/mobile-client/src/components/features/tracking/RunningMetricsDisplay.tsx
@@ -1,0 +1,232 @@
+/**
+ * RunningMetricsDisplay — TabularMetricDisplay featured layout (UX-DR4)
+ *
+ * Visual hierarchy (top → bottom):
+ *   ┌─────────────────────────────────────────────┐
+ *   │  PRIMARY: giant distance value + unit badge  │
+ *   │  11px label "DISTANCE" below                 │
+ *   ├─────────────────────────────────────────────┤
+ *   │  SECONDARY ROW:  DURÉE  │  ALLURE /KM       │
+ *   └─────────────────────────────────────────────┘
+ *
+ * All metrics: fontVariant tabular-nums, Inter_600SemiBold, no digit jitter.
+ * Accent (coral / cyan) applied to pace + unit badge — draws the eye.
+ */
+import { View, Text } from 'react-native';
+
+interface Props {
+  /** Raw distance in metres */
+  distanceMeters: number;
+  /** Elapsed seconds */
+  durationSeconds: number;
+  /** Pace in seconds/km (0 = not yet computable) */
+  paceSecsPerKm: number;
+  /** Main accent color (coral in light, coral in dark — Running sport color) */
+  accentColor: string;
+  /** Primary value text color */
+  valueColor: string;
+  /** Secondary value text color */
+  secondaryValueColor: string;
+  /** Label text color */
+  labelColor: string;
+  /** Divider color between primary and secondary sections */
+  dividerColor: string;
+  /** Card background */
+  cardBg: string;
+  /** Card outer border */
+  cardBorder: string;
+}
+
+// ─── Formatting (inline — same logic as lib/format-running.ts) ─────────────
+
+function fmtDistanceValue(m: number): string {
+  if (m < 1000) return String(Math.round(m));
+  return (m / 1000).toFixed(2);
+}
+
+function fmtDistanceUnit(m: number): string {
+  return m < 1000 ? 'm' : 'km';
+}
+
+function fmtDuration(totalSecs: number): string {
+  const mins = Math.floor(totalSecs / 60);
+  const secs = totalSecs % 60;
+  return `${String(mins).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
+}
+
+function fmtPace(secsPerKm: number): string {
+  if (secsPerKm <= 0) return "--'--";
+  const m = Math.floor(secsPerKm / 60);
+  const s = Math.round(secsPerKm % 60);
+  return `${m}'${String(s).padStart(2, '0')}"`;
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export function RunningMetricsDisplay({
+  distanceMeters,
+  durationSeconds,
+  paceSecsPerKm,
+  accentColor,
+  valueColor,
+  secondaryValueColor,
+  labelColor,
+  dividerColor,
+  cardBg,
+  cardBorder,
+}: Props) {
+  const distValue = fmtDistanceValue(distanceMeters);
+  const distUnit = fmtDistanceUnit(distanceMeters);
+  const duration = fmtDuration(durationSeconds);
+  const pace = fmtPace(paceSecsPerKm);
+
+  return (
+    <View
+      style={{
+        backgroundColor: cardBg,
+        borderBottomWidth: 1,
+        borderBottomColor: cardBorder,
+      }}
+    >
+      {/* ── PRIMARY: giant distance ───────────────────────────────────────── */}
+      <View
+        style={{
+          alignItems: 'center',
+          paddingTop: 24,
+          paddingBottom: 16,
+          paddingHorizontal: 24,
+        }}
+      >
+        {/* Value row — number + unit badge bottom-aligned */}
+        <View style={{ flexDirection: 'row', alignItems: 'flex-end', gap: 6 }}>
+          <Text
+            style={{
+              fontSize: 72,
+              fontWeight: '600',
+              fontFamily: 'Inter_600SemiBold',
+              fontVariant: ['tabular-nums'],
+              letterSpacing: -3,
+              lineHeight: 76,
+              color: valueColor,
+            }}
+          >
+            {distValue}
+          </Text>
+          <Text
+            style={{
+              fontSize: 24,
+              fontWeight: '600',
+              fontFamily: 'Inter_600SemiBold',
+              color: accentColor,
+              marginBottom: 10,
+              letterSpacing: -0.5,
+            }}
+          >
+            {distUnit}
+          </Text>
+        </View>
+
+        {/* 11px label */}
+        <Text
+          style={{
+            fontSize: 11,
+            color: labelColor,
+            fontFamily: 'Inter_400Regular',
+            letterSpacing: 1.2,
+            textTransform: 'uppercase',
+            marginTop: 4,
+          }}
+        >
+          Distance
+        </Text>
+      </View>
+
+      {/* ── Horizontal divider ────────────────────────────────────────────── */}
+      <View
+        style={{
+          height: 1,
+          backgroundColor: dividerColor,
+          marginHorizontal: 24,
+        }}
+      />
+
+      {/* ── SECONDARY ROW: duration | pace ───────────────────────────────── */}
+      <View
+        style={{
+          flexDirection: 'row',
+          paddingVertical: 16,
+        }}
+      >
+        {/* Durée */}
+        <View
+          style={{
+            flex: 1,
+            alignItems: 'center',
+            borderRightWidth: 1,
+            borderRightColor: dividerColor,
+          }}
+        >
+          <Text
+            style={{
+              fontSize: 42,
+              fontWeight: '600',
+              fontFamily: 'Inter_600SemiBold',
+              fontVariant: ['tabular-nums'],
+              letterSpacing: -1.5,
+              lineHeight: 46,
+              color: secondaryValueColor,
+            }}
+          >
+            {duration}
+          </Text>
+          <Text
+            style={{
+              fontSize: 11,
+              color: labelColor,
+              fontFamily: 'Inter_400Regular',
+              letterSpacing: 1,
+              textTransform: 'uppercase',
+              marginTop: 4,
+            }}
+          >
+            Durée
+          </Text>
+        </View>
+
+        {/* Allure */}
+        <View
+          style={{
+            flex: 1,
+            alignItems: 'center',
+          }}
+        >
+          <Text
+            style={{
+              fontSize: 42,
+              fontWeight: '600',
+              fontFamily: 'Inter_600SemiBold',
+              fontVariant: ['tabular-nums'],
+              letterSpacing: -1.5,
+              lineHeight: 46,
+              color: accentColor,
+            }}
+          >
+            {pace}
+          </Text>
+          <Text
+            style={{
+              fontSize: 11,
+              color: labelColor,
+              fontFamily: 'Inter_400Regular',
+              letterSpacing: 1,
+              textTransform: 'uppercase',
+              marginTop: 4,
+            }}
+          >
+            Allure /km
+          </Text>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/mobile-client/src/lib/format-running.ts
+++ b/mobile-client/src/lib/format-running.ts
@@ -1,0 +1,25 @@
+/**
+ * Formatting helpers for running metrics.
+ * Shared between the live tracking screen and the session summary card.
+ */
+
+/** Returns display value + unit separately so they can be styled differently */
+export function formatDistance(meters: number): { value: string; unit: string } {
+  if (meters < 1000) return { value: String(Math.round(meters)), unit: 'm' };
+  return { value: (meters / 1000).toFixed(2), unit: 'km' };
+}
+
+/** 512 s → "08:32" */
+export function formatDuration(totalSecs: number): string {
+  const m = Math.floor(totalSecs / 60);
+  const s = totalSecs % 60;
+  return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+}
+
+/** 330 s/km → "5'30"" — returns "--'--" until pace is computable */
+export function formatPace(secsPerKm: number): string {
+  if (secsPerKm <= 0) return "--'--";
+  const m = Math.floor(secsPerKm / 60);
+  const s = Math.round(secsPerKm % 60);
+  return `${m}'${String(s).padStart(2, '0')}"`;
+}


### PR DESCRIPTION
…-DR4)

- Add RunningMetricsDisplay: 72px primary distance + 42px duration/pace secondary
- Add lib/format-running.ts: shared formatDistance/Duration/Pace helpers
- Replace flat 3-tile MetricTile bar in running.tsx with RunningMetricsDisplay
- fontVariant tabular-nums on all values, coral accent on pace + unit badge
- Full dark mode support via prop-driven color tokens