### PR TITLE
feat(epic2/story2.4): Bouldering & route logging screen (climbing)

### DIFF
--- a/mobile-client/src/app/tracking/_layout.tsx
+++ b/mobile-client/src/app/tracking/_layout.tsx
@@ -7,6 +7,7 @@ export default function TrackingLayout() {
       {/* gestureEnabled: false — swipe-back disabled during active sessions (UX spec) */}
       <Stack.Screen name="session" options={{ gestureEnabled: false }} />
       <Stack.Screen name="running" options={{ gestureEnabled: false }} />
+      <Stack.Screen name="climbing" options={{ gestureEnabled: false }} />
     </Stack>
   );
 }

--- a/mobile-client/src/app/tracking/climbing.tsx
+++ b/mobile-client/src/app/tracking/climbing.tsx
@@ -1,0 +1,265 @@
+/**
+ * Climbing tracking screen — Story 2.4
+ *
+ * Layout (top → bottom):
+ *   1. Compact blue/cyan header  — sport label + discard button
+ *   2. Session timer             — elapsed HH:MM:SS (tabular-nums)
+ *   3. GradeDial                 — horizontal V-Scale selector (VB–V10)
+ *   4. StyleSelector             — Flash / Redpoint / Tentative
+ *   5. "Logger la voie" CTA      — 64px primary button (UX-DR10)
+ *   6. ClimbingLogPanel          — append-only route list + max grade
+ *   7. HoldToFinish stub         — Story 2.6 will replace this
+ */
+import { View, Text, Pressable, Alert } from 'react-native';
+import { router } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+import { colors } from '@/theme/colors';
+import { useSportStore } from '@/store/use-sport-store';
+import { useClimbingSession, V_GRADES } from '@/hooks/use-climbing-session';
+import { GradeDial } from '@/components/features/tracking/GradeDial';
+import { StyleSelector } from '@/components/features/tracking/StyleSelector';
+import { ClimbingLogPanel } from '@/components/features/tracking/ClimbingLogPanel';
+
+// ─── Timer formatter ──────────────────────────────────────────────────────────
+
+function fmtDuration(totalSecs: number): string {
+  const h = Math.floor(totalSecs / 3600);
+  const m = Math.floor((totalSecs % 3600) / 60);
+  const s = totalSecs % 60;
+  if (h > 0) {
+    return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+  }
+  return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export default function ClimbingScreen() {
+  const isDark = useColorScheme() === 'dark';
+  const { clearActiveSport } = useSportStore();
+  const {
+    metrics,
+    setSelectedGrade,
+    setSelectedStyle,
+    logRoute,
+    stopSession,
+  } = useClimbingSession();
+
+  // ── Design tokens ─────────────────────────────────────────────────────────
+  // Climbing: brand-blue light / cyan dark (design system)
+  const accent = isDark ? colors.primaryCyan : colors.brandBlue;
+  const accentBg = isDark ? 'rgba(56,189,248,0.12)' : '#EFF6FF';
+  const bg = isDark ? colors.darkBg : '#F8F9FA';
+  const cardBg = isDark ? colors.darkSurfaceAlt : '#FFFFFF';
+  const cardBorder = isDark ? colors.darkBorder : '#F3F4F6';
+  const textPrimary = isDark ? colors.darkText : '#1E293B';
+  const textMuted = isDark ? colors.placeholderDark : '#94A3B8';
+  const chipBg = isDark ? colors.darkSurface : '#F1F5F9';
+  const inactiveBorder = isDark ? colors.darkBorder : '#E5E7EB';
+
+  // ── Handlers ─────────────────────────────────────────────────────────────
+
+  function handleDiscard() {
+    Alert.alert(
+      'Abandonner la session ?',
+      'Tes voies non sauvegardées seront perdues.',
+      [
+        { text: 'Continuer', style: 'cancel' },
+        {
+          text: 'Abandonner',
+          style: 'destructive',
+          onPress: () => {
+            stopSession();
+            clearActiveSport();
+            router.replace('/(tabs)/' as any);
+          },
+        },
+      ],
+    );
+  }
+
+  return (
+    <View style={{ flex: 1, backgroundColor: bg }}>
+
+      {/* ── 1. Compact header ───────────────────────────────────────────────── */}
+      <View
+        style={{
+          backgroundColor: accent,
+          paddingTop: 56,
+          paddingBottom: 16,
+          paddingHorizontal: 24,
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+          <Ionicons name="trail-sign-outline" size={22} color="#FFFFFF" />
+          <Text
+            style={{
+              fontSize: 17,
+              fontWeight: '600',
+              color: '#FFFFFF',
+              fontFamily: 'Inter_600SemiBold',
+              letterSpacing: -0.3,
+            }}
+          >
+            Escalade
+          </Text>
+        </View>
+        <Pressable
+          onPress={handleDiscard}
+          hitSlop={12}
+          style={{
+            width: 36,
+            height: 36,
+            borderRadius: 18,
+            backgroundColor: 'rgba(255,255,255,0.2)',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <Ionicons name="close" size={20} color="#FFFFFF" />
+        </Pressable>
+      </View>
+
+      {/* ── 2. Session timer (tabular-nums) ─────────────────────────────────── */}
+      <View
+        style={{
+          backgroundColor: cardBg,
+          borderBottomWidth: 1,
+          borderBottomColor: cardBorder,
+          alignItems: 'center',
+          paddingVertical: 16,
+        }}
+      >
+        <Text
+          style={{
+            fontSize: 48,
+            fontWeight: '600',
+            fontFamily: 'Inter_600SemiBold',
+            fontVariant: ['tabular-nums'],
+            letterSpacing: -2,
+            lineHeight: 52,
+            color: textPrimary,
+          }}
+        >
+          {fmtDuration(metrics.durationSeconds)}
+        </Text>
+        <Text
+          style={{
+            fontSize: 11,
+            color: textMuted,
+            fontFamily: 'Inter_400Regular',
+            letterSpacing: 1.2,
+            textTransform: 'uppercase',
+            marginTop: 4,
+          }}
+        >
+          Durée de session
+        </Text>
+      </View>
+
+      {/* ── Scrollable input area (grade dial + style + CTA) ────────────────── */}
+      <View style={{ backgroundColor: cardBg }}>
+
+        {/* ── 3. Grade dial ──────────────────────────────────────────────────── */}
+        <GradeDial
+          grades={V_GRADES}
+          selected={metrics.selectedGrade}
+          onSelect={setSelectedGrade}
+          accentColor={accent}
+          textColor={textPrimary}
+          chipBg={chipBg}
+          chipBgActive={accent}
+        />
+
+        {/* ── 4. Style selector ──────────────────────────────────────────────── */}
+        <StyleSelector
+          selected={metrics.selectedStyle}
+          onSelect={setSelectedStyle}
+          accentColor={accent}
+          accentBg={accentBg}
+          textColor={textPrimary}
+          inactiveBg={chipBg}
+          inactiveBorder={inactiveBorder}
+        />
+
+        {/* ── 5. Log route CTA — 64px (UX-DR10) ─────────────────────────────── */}
+        <View style={{ paddingHorizontal: 24, paddingTop: 8, paddingBottom: 16 }}>
+          <Pressable
+            onPress={logRoute}
+            style={({ pressed }) => ({
+              minHeight: 64,
+              borderRadius: 20,
+              backgroundColor: accent,
+              alignItems: 'center',
+              justifyContent: 'center',
+              flexDirection: 'row',
+              gap: 10,
+              opacity: pressed ? 0.88 : 1,
+            })}
+          >
+            <Ionicons name="add-circle-outline" size={22} color="#FFFFFF" />
+            <Text
+              style={{
+                fontSize: 16,
+                fontWeight: '600',
+                color: '#FFFFFF',
+                fontFamily: 'Inter_600SemiBold',
+                letterSpacing: -0.3,
+              }}
+            >
+              Logger la voie ({metrics.selectedGrade})
+            </Text>
+          </Pressable>
+        </View>
+      </View>
+
+      {/* ── 6. Route log panel ──────────────────────────────────────────────── */}
+      <ClimbingLogPanel
+        routes={metrics.routes}
+        accentColor={accent}
+        accentBg={accentBg}
+        textColor={textPrimary}
+        textMuted={textMuted}
+        cardBg={cardBg}
+        cardBorder={cardBorder}
+        maxGrade={metrics.maxGrade}
+      />
+
+      {/* ── 7. HoldToFinish stub — Story 2.6 ───────────────────────────────── */}
+      <View
+        style={{
+          paddingHorizontal: 24,
+          paddingBottom: 40,
+          paddingTop: 12,
+          backgroundColor: bg,
+        }}
+      >
+        <View
+          style={{
+            minHeight: 64,
+            alignItems: 'center',
+            justifyContent: 'center',
+            borderRadius: 20,
+            backgroundColor: accent,
+            opacity: 0.45,
+          }}
+        >
+          <Text
+            style={{
+              fontSize: 15,
+              fontWeight: '600',
+              color: '#FFFFFF',
+              fontFamily: 'Inter_600SemiBold',
+            }}
+          >
+            Maintenir pour terminer — Story 2.6
+          </Text>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/mobile-client/src/app/tracking/index.tsx
+++ b/mobile-client/src/app/tracking/index.tsx
@@ -26,6 +26,8 @@ export default function SportSelectScreen() {
     // Running has its own screen (Story 2.2); others still use the generic session stub
     if (sport === 'running') {
       router.push('/tracking/running' as any);
+    } else if (sport === 'climbing') {
+      router.push('/tracking/climbing' as any);
     } else {
       router.push('/tracking/session' as any);
     }

--- a/mobile-client/src/components/features/tracking/ClimbingLogPanel.tsx
+++ b/mobile-client/src/components/features/tracking/ClimbingLogPanel.tsx
@@ -1,0 +1,243 @@
+/**
+ * ClimbingLogPanel — logged routes list (Story 2.4)
+ *
+ * Renders the append-only list of routes logged during the session.
+ * Each row shows: grade chip | style badge | relative time.
+ * Empty state: prompt to log the first route.
+ */
+import { View, Text, ScrollView } from 'react-native';
+import type { ClimbingRoute, ClimbStyle } from '@/hooks/use-climbing-session';
+
+// ─── Style meta ───────────────────────────────────────────────────────────────
+
+const STYLE_META: Record<ClimbStyle, { label: string; emoji: string }> = {
+  flash: { label: 'Flash', emoji: '⚡' },
+  redpoint: { label: 'Redpoint', emoji: '🔴' },
+  tentative: { label: 'Tentative', emoji: '🔄' },
+};
+
+// ─── Relative time helper ─────────────────────────────────────────────────────
+
+function relativeTime(ts: number): string {
+  const diffSecs = Math.floor((Date.now() - ts) / 1000);
+  if (diffSecs < 60) return `${diffSecs}s`;
+  return `${Math.floor(diffSecs / 60)}min`;
+}
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface Props {
+  routes: ClimbingRoute[];
+  accentColor: string;
+  accentBg: string;
+  textColor: string;
+  textMuted: string;
+  cardBg: string;
+  cardBorder: string;
+  maxGrade: string;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function ClimbingLogPanel({
+  routes,
+  accentColor,
+  accentBg,
+  textColor,
+  textMuted,
+  cardBg,
+  cardBorder,
+  maxGrade,
+}: Props) {
+  return (
+    <View style={{ flex: 1 }}>
+      {/* ── Header row ─────────────────────────────────────────────────────── */}
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          paddingHorizontal: 24,
+          paddingVertical: 10,
+          borderTopWidth: 1,
+          borderTopColor: cardBorder,
+          backgroundColor: cardBg,
+        }}
+      >
+        <Text
+          style={{
+            fontSize: 13,
+            fontWeight: '600',
+            fontFamily: 'Inter_600SemiBold',
+            color: textColor,
+            letterSpacing: -0.2,
+          }}
+        >
+          Voies ({routes.length})
+        </Text>
+
+        {maxGrade !== '' && (
+          <View
+            style={{
+              flexDirection: 'row',
+              alignItems: 'center',
+              gap: 4,
+              backgroundColor: accentBg,
+              borderRadius: 10,
+              paddingHorizontal: 10,
+              paddingVertical: 4,
+            }}
+          >
+            <Text
+              style={{
+                fontSize: 11,
+                color: textMuted,
+                fontFamily: 'Inter_400Regular',
+                letterSpacing: 0.5,
+                textTransform: 'uppercase',
+              }}
+            >
+              Max
+            </Text>
+            <Text
+              style={{
+                fontSize: 13,
+                fontWeight: '700',
+                fontFamily: 'Inter_700Bold',
+                color: accentColor,
+                letterSpacing: -0.3,
+              }}
+            >
+              {maxGrade}
+            </Text>
+          </View>
+        )}
+      </View>
+
+      {/* ── Route list ─────────────────────────────────────────────────────── */}
+      {routes.length === 0 ? (
+        <View
+          style={{
+            flex: 1,
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 8,
+            paddingHorizontal: 32,
+          }}
+        >
+          <Text style={{ fontSize: 32 }}>🧗</Text>
+          <Text
+            style={{
+              fontSize: 15,
+              fontWeight: '600',
+              fontFamily: 'Inter_600SemiBold',
+              color: textColor,
+              textAlign: 'center',
+            }}
+          >
+            Prêt à grimper
+          </Text>
+          <Text
+            style={{
+              fontSize: 13,
+              color: textMuted,
+              fontFamily: 'Inter_400Regular',
+              textAlign: 'center',
+              lineHeight: 18,
+            }}
+          >
+            Sélectionne un grade et un style{'\n'}puis appuie sur «&nbsp;Logger la voie&nbsp;»
+          </Text>
+        </View>
+      ) : (
+        <ScrollView
+          style={{ flex: 1 }}
+          contentContainerStyle={{ paddingHorizontal: 24, paddingTop: 8, paddingBottom: 24, gap: 8 }}
+          showsVerticalScrollIndicator={false}
+        >
+          {routes.map((route, idx) => {
+            const meta = STYLE_META[route.style];
+            return (
+              <View
+                key={route.id}
+                style={{
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  gap: 14,
+                  paddingVertical: 12,
+                  paddingHorizontal: 16,
+                  backgroundColor: cardBg,
+                  borderRadius: 14,
+                  borderWidth: 1,
+                  borderColor: cardBorder,
+                }}
+              >
+                {/* Route number */}
+                <Text
+                  style={{
+                    fontSize: 12,
+                    color: textMuted,
+                    fontFamily: 'Inter_400Regular',
+                    width: 20,
+                    textAlign: 'right',
+                  }}
+                >
+                  {routes.length - idx}
+                </Text>
+
+                {/* Grade chip */}
+                <View
+                  style={{
+                    backgroundColor: accentBg,
+                    borderRadius: 10,
+                    paddingHorizontal: 10,
+                    paddingVertical: 4,
+                    minWidth: 44,
+                    alignItems: 'center',
+                  }}
+                >
+                  <Text
+                    style={{
+                      fontSize: 14,
+                      fontWeight: '700',
+                      fontFamily: 'Inter_700Bold',
+                      color: accentColor,
+                      letterSpacing: -0.3,
+                    }}
+                  >
+                    {route.grade}
+                  </Text>
+                </View>
+
+                {/* Style badge */}
+                <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4, flex: 1 }}>
+                  <Text style={{ fontSize: 13 }}>{meta.emoji}</Text>
+                  <Text
+                    style={{
+                      fontSize: 13,
+                      color: textColor,
+                      fontFamily: 'Inter_400Regular',
+                    }}
+                  >
+                    {meta.label}
+                  </Text>
+                </View>
+
+                {/* Relative time */}
+                <Text
+                  style={{
+                    fontSize: 12,
+                    color: textMuted,
+                    fontFamily: 'Inter_400Regular',
+                  }}
+                >
+                  {relativeTime(route.loggedAt)}
+                </Text>
+              </View>
+            );
+          })}
+        </ScrollView>
+      )}
+    </View>
+  );
+}

--- a/mobile-client/src/components/features/tracking/GradeDial.tsx
+++ b/mobile-client/src/components/features/tracking/GradeDial.tsx
@@ -1,0 +1,168 @@
+/**
+ * GradeDial — horizontal grade selector (Story 2.4)
+ *
+ * Renders a snapping horizontal FlatList of grade chips (VB–V10).
+ * The centred item is the selected grade — highlighted with the sport accent.
+ * 64×64px touch targets on each chip (UX-DR10).
+ *
+ * Props:
+ *   grades       — ordered array of grade strings
+ *   selected     — currently selected grade
+ *   onSelect     — callback when user taps a grade
+ *   accentColor  — active chip background / text (climbing blue/cyan)
+ *   textColor    — inactive chip text
+ *   chipBg       — inactive chip background
+ */
+import { useRef, useCallback } from 'react';
+import {
+  FlatList,
+  View,
+  Text,
+  Pressable,
+  type ListRenderItemInfo,
+  type ViewToken,
+} from 'react-native';
+
+interface Props {
+  grades: string[];
+  selected: string;
+  onSelect: (grade: string) => void;
+  accentColor: string;
+  textColor: string;
+  chipBg: string;
+  chipBgActive: string;
+}
+
+const CHIP_SIZE = 64;
+const CHIP_GAP = 12;
+const ITEM_WIDTH = CHIP_SIZE + CHIP_GAP;
+
+export function GradeDial({
+  grades,
+  selected,
+  onSelect,
+  accentColor,
+  textColor,
+  chipBg,
+  chipBgActive,
+}: Props) {
+  const listRef = useRef<FlatList<string>>(null);
+
+  const scrollToGrade = useCallback(
+    (grade: string) => {
+      const idx = grades.indexOf(grade);
+      if (idx !== -1) {
+        listRef.current?.scrollToIndex({ index: idx, animated: true, viewPosition: 0.5 });
+      }
+    },
+    [grades],
+  );
+
+  const handleSelect = useCallback(
+    (grade: string) => {
+      onSelect(grade);
+      scrollToGrade(grade);
+    },
+    [onSelect, scrollToGrade],
+  );
+
+  // Snap to nearest grade when scroll settles
+  const onViewableItemsChanged = useCallback(
+    ({ viewableItems }: { viewableItems: ViewToken[] }) => {
+      if (viewableItems.length > 0) {
+        const centre = viewableItems[Math.floor(viewableItems.length / 2)];
+        if (centre?.item && centre.item !== selected) {
+          onSelect(centre.item as string);
+        }
+      }
+    },
+    [selected, onSelect],
+  );
+
+  const viewabilityConfig = { itemVisiblePercentThreshold: 60 };
+
+  function renderItem({ item }: ListRenderItemInfo<string>) {
+    const isActive = item === selected;
+    return (
+      <Pressable
+        onPress={() => handleSelect(item)}
+        style={{
+          width: CHIP_SIZE,
+          height: CHIP_SIZE,
+          borderRadius: CHIP_SIZE / 2,
+          backgroundColor: isActive ? chipBgActive : chipBg,
+          alignItems: 'center',
+          justifyContent: 'center',
+          marginRight: CHIP_GAP,
+          // Subtle scale hint handled via opacity
+        }}
+      >
+        <Text
+          style={{
+            fontSize: isActive ? 18 : 15,
+            fontWeight: isActive ? '700' : '500',
+            fontFamily: isActive ? 'Inter_700Bold' : 'Inter_500Medium',
+            color: isActive ? '#FFFFFF' : textColor,
+            letterSpacing: -0.3,
+          }}
+        >
+          {item}
+        </Text>
+      </Pressable>
+    );
+  }
+
+  return (
+    <View style={{ paddingVertical: 12 }}>
+      {/* Label */}
+      <Text
+        style={{
+          fontSize: 11,
+          color: accentColor,
+          fontFamily: 'Inter_500Medium',
+          letterSpacing: 1.2,
+          textTransform: 'uppercase',
+          paddingHorizontal: 24,
+          marginBottom: 12,
+        }}
+      >
+        Grade
+      </Text>
+
+      <FlatList
+        ref={listRef}
+        data={grades}
+        keyExtractor={(g) => g}
+        renderItem={renderItem}
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        snapToInterval={ITEM_WIDTH}
+        decelerationRate="fast"
+        contentContainerStyle={{ paddingHorizontal: 24 }}
+        onViewableItemsChanged={onViewableItemsChanged}
+        viewabilityConfig={viewabilityConfig}
+        initialScrollIndex={grades.indexOf(selected)}
+        getItemLayout={(_data, index) => ({
+          length: ITEM_WIDTH,
+          offset: ITEM_WIDTH * index,
+          index,
+        })}
+      />
+
+      {/* Selected grade large display */}
+      <Text
+        style={{
+          fontSize: 48,
+          fontWeight: '700',
+          fontFamily: 'Inter_700Bold',
+          color: accentColor,
+          textAlign: 'center',
+          letterSpacing: -2,
+          marginTop: 8,
+        }}
+      >
+        {selected}
+      </Text>
+    </View>
+  );
+}

--- a/mobile-client/src/components/features/tracking/StyleSelector.tsx
+++ b/mobile-client/src/components/features/tracking/StyleSelector.tsx
@@ -1,0 +1,99 @@
+/**
+ * StyleSelector — Flash / Redpoint / Tentative pill buttons (Story 2.4)
+ *
+ * Three equally-wide pill buttons. The active style gets the sport accent.
+ * Min height 48px (secondary action target — UX-DR10).
+ *
+ * Flash     — sent on first attempt (no prior beta knowledge)
+ * Redpoint  — sent after prior attempts / beta
+ * Tentative — did not complete (partial, fall, attempt)
+ */
+import { View, Text, Pressable } from 'react-native';
+import type { ClimbStyle } from '@/hooks/use-climbing-session';
+
+interface StyleOption {
+  value: ClimbStyle;
+  label: string;
+  emoji: string;
+}
+
+const STYLES: StyleOption[] = [
+  { value: 'flash', label: 'Flash', emoji: '⚡' },
+  { value: 'redpoint', label: 'Redpoint', emoji: '🔴' },
+  { value: 'tentative', label: 'Tentative', emoji: '🔄' },
+];
+
+interface Props {
+  selected: ClimbStyle;
+  onSelect: (style: ClimbStyle) => void;
+  accentColor: string;
+  accentBg: string;
+  textColor: string;
+  inactiveBg: string;
+  inactiveBorder: string;
+}
+
+export function StyleSelector({
+  selected,
+  onSelect,
+  accentColor,
+  accentBg,
+  textColor,
+  inactiveBg,
+  inactiveBorder,
+}: Props) {
+  return (
+    <View style={{ paddingHorizontal: 24, paddingVertical: 12 }}>
+      <Text
+        style={{
+          fontSize: 11,
+          color: accentColor,
+          fontFamily: 'Inter_500Medium',
+          letterSpacing: 1.2,
+          textTransform: 'uppercase',
+          marginBottom: 12,
+        }}
+      >
+        Style
+      </Text>
+
+      <View style={{ flexDirection: 'row', gap: 10 }}>
+        {STYLES.map(({ value, label, emoji }) => {
+          const isActive = value === selected;
+          return (
+            <Pressable
+              key={value}
+              onPress={() => onSelect(value)}
+              style={({ pressed }) => ({
+                flex: 1,
+                minHeight: 48,
+                borderRadius: 14,
+                alignItems: 'center',
+                justifyContent: 'center',
+                backgroundColor: isActive ? accentBg : inactiveBg,
+                borderWidth: 1.5,
+                borderColor: isActive ? accentColor : inactiveBorder,
+                gap: 2,
+                opacity: pressed ? 0.8 : 1,
+                paddingVertical: 10,
+              })}
+            >
+              <Text style={{ fontSize: 16 }}>{emoji}</Text>
+              <Text
+                style={{
+                  fontSize: 12,
+                  fontWeight: isActive ? '600' : '400',
+                  fontFamily: isActive ? 'Inter_600SemiBold' : 'Inter_400Regular',
+                  color: isActive ? accentColor : textColor,
+                  letterSpacing: -0.2,
+                }}
+              >
+                {label}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+    </View>
+  );
+}

--- a/mobile-client/src/hooks/use-climbing-session.ts
+++ b/mobile-client/src/hooks/use-climbing-session.ts
@@ -1,0 +1,110 @@
+/**
+ * use-climbing-session — Story 2.4
+ *
+ * Manages climbing session state:
+ *   - 1-second elapsed timer
+ *   - Selected grade (V0–V10) and style (Flash / Redpoint / Tentative)
+ *   - Route log (append-only list of logged routes)
+ *
+ * Cleans up the timer on unmount.
+ */
+import { useState, useEffect, useRef, useCallback } from 'react';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type ClimbStyle = 'flash' | 'redpoint' | 'tentative';
+
+export interface ClimbingRoute {
+  id: string;
+  grade: string;        // e.g. "V3"
+  style: ClimbStyle;
+  loggedAt: number;     // Date.now() timestamp
+}
+
+export interface ClimbingMetrics {
+  durationSeconds: number;
+  selectedGrade: string;
+  selectedStyle: ClimbStyle;
+  routes: ClimbingRoute[];
+  /** Computed max grade logged so far, or '' if none */
+  maxGrade: string;
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+export const V_GRADES = [
+  'VB', 'V0', 'V1', 'V2', 'V3', 'V4', 'V5', 'V6', 'V7', 'V8', 'V9', 'V10',
+];
+
+const DEFAULT_GRADE = 'V3';
+const DEFAULT_STYLE: ClimbStyle = 'redpoint';
+
+// ─── Grade rank helper ────────────────────────────────────────────────────────
+
+function gradeRank(grade: string): number {
+  return V_GRADES.indexOf(grade);
+}
+
+function computeMaxGrade(routes: ClimbingRoute[]): string {
+  if (routes.length === 0) return '';
+  return routes.reduce((best, r) =>
+    gradeRank(r.grade) > gradeRank(best) ? r.grade : best,
+    routes[0].grade,
+  );
+}
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+export function useClimbingSession() {
+  const [durationSeconds, setDurationSeconds] = useState(0);
+  const [selectedGrade, setSelectedGrade] = useState(DEFAULT_GRADE);
+  const [selectedStyle, setSelectedStyle] = useState<ClimbStyle>(DEFAULT_STYLE);
+  const [routes, setRoutes] = useState<ClimbingRoute[]>([]);
+
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Start 1-second timer on mount
+  useEffect(() => {
+    timerRef.current = setInterval(() => {
+      setDurationSeconds((s) => s + 1);
+    }, 1000);
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, []);
+
+  const stopSession = useCallback(() => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const logRoute = useCallback(() => {
+    const route: ClimbingRoute = {
+      id: `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+      grade: selectedGrade,
+      style: selectedStyle,
+      loggedAt: Date.now(),
+    };
+    setRoutes((prev) => [route, ...prev]);
+  }, [selectedGrade, selectedStyle]);
+
+  const maxGrade = computeMaxGrade(routes);
+
+  const metrics: ClimbingMetrics = {
+    durationSeconds,
+    selectedGrade,
+    selectedStyle,
+    routes,
+    maxGrade,
+  };
+
+  return {
+    metrics,
+    setSelectedGrade,
+    setSelectedStyle,
+    logRoute,
+    stopSession,
+  };
+}


### PR DESCRIPTION
## Summary

- Full climbing tracking screen with grade dial (VB–V10), style selector (Flash/Redpoint/Tentative), and route log panel
- `GradeDial` — horizontal snapping FlatList, 64px chips, active grade in accent color
- `StyleSelector` — 3 pills with emoji labels, 48px min-height, per-theme accent (brand-blue/cyan)
- `ClimbingLogPanel` — append-only log, max grade badge, relative timestamps, empty state
- `use-climbing-session` hook — 1s timer, logRoute, computeMaxGrade, stopSession (no memory leak)
- `climbing.tsx` screen — header compact bleu/cyan (UX-DR2), CTA 64px, HoldToFinish stub (Story 2.6)
- 0 TypeScript errors · 0 lint errors

## Design decisions

- **FlatList over reanimated** — snapping FlatList sufficient for grade dial; reanimated deferred to Story 2.6 (HoldToFinish)
- **VB grade included** — covers beginner persona from PRD
- **Props color tokens** — same pattern as RunningMetricsDisplay; components are pure and testable

## Test plan

- [ ] Launch climbing session from home screen — verify routing works
- [ ] Scroll GradeDial, tap grade — verify selection highlights and display updates
- [ ] Tap each StyleSelector pill — verify accent color switches
- [ ] Tap "Logger la voie" — verify route appended in ClimbingLogPanel with correct grade + style
- [ ] Verify max grade badge updates in real time
- [ ] Discard session — verify timer stops (no leak)
- [ ] Test in light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)