### PR TITLE
feat(epic2/story2.7): discard session native bottom-sheet (UX-DR12)

### DIFF
--- a/mobile-client/package-lock.json
+++ b/mobile-client/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo-google-fonts/inter": "^0.4.2",
+        "@expo/react-native-action-sheet": "^4.1.1",
         "@expo/vector-icons": "^15.0.3",
         "@react-navigation/bottom-tabs": "^7.4.0",
         "@react-navigation/elements": "^2.6.3",
@@ -2176,6 +2177,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/@expo/react-native-action-sheet": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@expo/react-native-action-sheet/-/react-native-action-sheet-4.1.1.tgz",
+      "integrity": "sha512-4KRaba2vhqDRR7ObBj6nrD5uJw8ePoNHdIOMETTpgGTX7StUbrF4j/sfrP1YUyaPEa1P8FXdwG6pB+2WtrJd1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "hoist-non-react-statics": "^3.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0"
+      }
+    },
     "node_modules/@expo/require-utils": {
       "version": "55.0.3",
       "resolved": "https://registry.npmjs.org/@expo/require-utils/-/require-utils-55.0.3.tgz",
@@ -3707,6 +3721,18 @@
       "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
       "license": "MIT"
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
+      "integrity": "sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==",
+      "license": "MIT",
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -3781,7 +3807,6 @@
       "version": "19.1.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.17.tgz",
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -5882,7 +5907,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {

--- a/mobile-client/package.json
+++ b/mobile-client/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@expo-google-fonts/inter": "^0.4.2",
+    "@expo/react-native-action-sheet": "^4.1.1",
     "@expo/vector-icons": "^15.0.3",
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",

--- a/mobile-client/src/__tests__/use-discard-sheet.test.ts
+++ b/mobile-client/src/__tests__/use-discard-sheet.test.ts
@@ -1,0 +1,88 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { Alert, Platform } from 'react-native';
+import { useDiscardSheet } from '@/hooks/use-discard-sheet';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockShowActionSheet = jest.fn();
+
+jest.mock('@expo/react-native-action-sheet', () => ({
+  useActionSheet: () => ({ showActionSheetWithOptions: mockShowActionSheet }),
+}));
+
+jest.spyOn(Alert, 'alert');
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('useDiscardSheet', () => {
+  const OPTIONS = {
+    title: 'Abandonner la session ?',
+    message: 'Ta progression sera perdue.',
+    confirmLabel: 'Abandonner',
+    onConfirm: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('iOS', () => {
+    beforeAll(() => {
+      (Platform as any).OS = 'ios';
+    });
+
+    it('calls showActionSheetWithOptions with destructive index 0 and cancel index 1', () => {
+      const { result } = renderHook(() => useDiscardSheet());
+      act(() => result.current(OPTIONS));
+
+      expect(mockShowActionSheet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          options: ['Abandonner', 'Continuer'],
+          destructiveButtonIndex: 0,
+          cancelButtonIndex: 1,
+        }),
+        expect.any(Function),
+      );
+    });
+
+    it('fires onConfirm when destructive index (0) is selected', () => {
+      const { result } = renderHook(() => useDiscardSheet());
+      act(() => result.current(OPTIONS));
+
+      const callback = mockShowActionSheet.mock.calls[0][1] as (i: number) => void;
+      act(() => callback(0));
+
+      expect(OPTIONS.onConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT fire onConfirm when cancel index (1) is selected', () => {
+      const { result } = renderHook(() => useDiscardSheet());
+      act(() => result.current(OPTIONS));
+
+      const callback = mockShowActionSheet.mock.calls[0][1] as (i: number) => void;
+      act(() => callback(1));
+
+      expect(OPTIONS.onConfirm).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Android', () => {
+    beforeAll(() => {
+      (Platform as any).OS = 'android';
+    });
+
+    it('falls back to Alert.alert with a destructive button', () => {
+      const { result } = renderHook(() => useDiscardSheet());
+      act(() => result.current(OPTIONS));
+
+      expect(Alert.alert).toHaveBeenCalledWith(
+        OPTIONS.title,
+        OPTIONS.message,
+        expect.arrayContaining([
+          expect.objectContaining({ style: 'destructive', text: 'Abandonner' }),
+          expect.objectContaining({ style: 'cancel' }),
+        ]),
+      );
+    });
+  });
+});

--- a/mobile-client/src/app/_layout.tsx
+++ b/mobile-client/src/app/_layout.tsx
@@ -1,5 +1,6 @@
 import '../../global.css';
 
+import { ActionSheetProvider } from '@expo/react-native-action-sheet';
 import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
 import {
   Inter_400Regular,
@@ -70,6 +71,7 @@ export default function RootLayout() {
   // The native splash screen stays visible until SplashScreen.hideAsync() is called.
   return (
     <QueryClientProvider client={queryClient}>
+      <ActionSheetProvider>
       <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
         <Stack>
           <Stack.Screen name="index" options={{ headerShown: false }} />
@@ -84,6 +86,7 @@ export default function RootLayout() {
         </Stack>
         <StatusBar style="auto" />
       </ThemeProvider>
+      </ActionSheetProvider>
     </QueryClientProvider>
   );
 }

--- a/mobile-client/src/app/tracking/climbing.tsx
+++ b/mobile-client/src/app/tracking/climbing.tsx
@@ -10,7 +10,7 @@
  *   6. ClimbingLogPanel          — append-only route list + max grade
  *   7. HoldToFinishButton        — 1.5s hold, SVG ring, haptics (UX-DR3)
  */
-import { View, Text, Pressable, Alert } from 'react-native';
+import { View, Text, Pressable } from 'react-native';
 import { router } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { useColorScheme } from '@/hooks/use-color-scheme';
@@ -21,6 +21,7 @@ import { GradeDial } from '@/components/features/tracking/GradeDial';
 import { StyleSelector } from '@/components/features/tracking/StyleSelector';
 import { ClimbingLogPanel } from '@/components/features/tracking/ClimbingLogPanel';
 import { HoldToFinishButton } from '@/components/features/tracking/HoldToFinishButton';
+import { useDiscardSheet } from '@/hooks/use-discard-sheet';
 
 // ─── Timer formatter ──────────────────────────────────────────────────────────
 
@@ -46,6 +47,7 @@ export default function ClimbingScreen() {
     logRoute,
     stopSession,
   } = useClimbingSession();
+  const showDiscard = useDiscardSheet();
 
   // ── Design tokens ─────────────────────────────────────────────────────────
   const accent = isDark ? colors.primaryCyan : colors.brandBlue;
@@ -61,22 +63,16 @@ export default function ClimbingScreen() {
   // ── Handlers ─────────────────────────────────────────────────────────────
 
   function handleDiscard() {
-    Alert.alert(
-      'Abandonner la session ?',
-      'Tes voies non sauvegardées seront perdues.',
-      [
-        { text: 'Continuer', style: 'cancel' },
-        {
-          text: 'Abandonner',
-          style: 'destructive',
-          onPress: () => {
-            stopSession();
-            clearActiveSport();
-            router.replace('/(tabs)/' as any);
-          },
-        },
-      ],
-    );
+    showDiscard({
+      title: 'Abandonner la session ?',
+      message: 'Tes voies non sauvegardées seront perdues.',
+      confirmLabel: 'Abandonner',
+      onConfirm: () => {
+        stopSession();
+        clearActiveSport();
+        router.replace('/(tabs)/' as any);
+      },
+    });
   }
 
   return (

--- a/mobile-client/src/app/tracking/running.tsx
+++ b/mobile-client/src/app/tracking/running.tsx
@@ -8,7 +8,7 @@
  *   4. GPS status chip       — lock indicator
  *   5. HoldToFinishButton    — 1.5s hold, SVG ring, haptics (UX-DR3)
  */
-import { View, Text, Pressable, Alert, ActivityIndicator } from 'react-native';
+import { View, Text, Pressable, ActivityIndicator } from 'react-native';
 import MapView, { Polyline, Marker, PROVIDER_DEFAULT } from 'react-native-maps';
 import { router } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
@@ -18,6 +18,7 @@ import { useSportStore } from '@/store/use-sport-store';
 import { useRunningTracker } from '@/hooks/use-running-tracker';
 import { RunningMetricsDisplay } from '@/components/features/tracking/RunningMetricsDisplay';
 import { HoldToFinishButton } from '@/components/features/tracking/HoldToFinishButton';
+import { useDiscardSheet } from '@/hooks/use-discard-sheet';
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
@@ -25,6 +26,7 @@ export default function RunningScreen() {
   const isDark = useColorScheme() === 'dark';
   const { clearActiveSport } = useSportStore();
   const { metrics, stopTracking } = useRunningTracker();
+  const showDiscard = useDiscardSheet();
 
   // ── Design tokens ───────────────────────────────────────────────────────────
   const accent = colors.brandOrange;          // Running = coral always
@@ -36,22 +38,16 @@ export default function RunningScreen() {
   const metricDivider = isDark ? colors.darkBorder : '#E5E7EB';
 
   function handleDiscard() {
-    Alert.alert(
-      'Abandonner la course ?',
-      'Ta progression sera perdue.',
-      [
-        { text: 'Continuer', style: 'cancel' },
-        {
-          text: 'Abandonner',
-          style: 'destructive',
-          onPress: () => {
-            stopTracking();
-            clearActiveSport();
-            router.replace('/(tabs)/' as any);
-          },
-        },
-      ],
-    );
+    showDiscard({
+      title: 'Abandonner la course ?',
+      message: 'Ta progression sera perdue.',
+      confirmLabel: 'Abandonner',
+      onConfirm: () => {
+        stopTracking();
+        clearActiveSport();
+        router.replace('/(tabs)/' as any);
+      },
+    });
   }
 
   // ── Permission denied ───────────────────────────────────────────────────────

--- a/mobile-client/src/app/tracking/weightlifting.tsx
+++ b/mobile-client/src/app/tracking/weightlifting.tsx
@@ -11,7 +11,7 @@
  *   7. WorkoutLogPanel        — append-only set list + total volume
  *   8. HoldToFinishButton     — 1.5s hold, SVG ring, haptics (UX-DR3)
  */
-import { View, Text, Pressable, Alert } from 'react-native';
+import { View, Text, Pressable } from 'react-native';
 import { router } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { useColorScheme } from '@/hooks/use-color-scheme';
@@ -26,6 +26,7 @@ import { ExercisePicker } from '@/components/features/tracking/ExercisePicker';
 import { SetInputRow } from '@/components/features/tracking/SetInputRow';
 import { WorkoutLogPanel } from '@/components/features/tracking/WorkoutLogPanel';
 import { HoldToFinishButton } from '@/components/features/tracking/HoldToFinishButton';
+import { useDiscardSheet } from '@/hooks/use-discard-sheet';
 
 // ─── Timer formatter ──────────────────────────────────────────────────────────
 
@@ -53,6 +54,7 @@ export default function WeightliftingScreen() {
     dismissRest,
     stopSession,
   } = useWeightliftingSession();
+  const showDiscard = useDiscardSheet();
 
   // ── Design tokens (Musculation: purple) ───────────────────────────────────
   const sportCfg  = SPORT_CONFIG.weightlifting;
@@ -69,21 +71,15 @@ export default function WeightliftingScreen() {
   // ── Handlers ─────────────────────────────────────────────────────────────
 
   function handleDiscard() {
-    Alert.alert(
-      'Abandonner la séance ?',
-      'Tes séries non sauvegardées seront perdues.',
-      [
-        { text: 'Continuer', style: 'cancel' },
-        {
-          text: 'Abandonner',
-          style: 'destructive',
-          onPress: () => {
-            stopSession();
-            router.replace('/(tabs)/' as any);
-          },
-        },
-      ],
-    );
+    showDiscard({
+      title: 'Abandonner la séance ?',
+      message: 'Tes séries non sauvegardées seront perdues.',
+      confirmLabel: 'Abandonner',
+      onConfirm: () => {
+        stopSession();
+        router.replace('/(tabs)/' as any);
+      },
+    });
   }
 
   return (

--- a/mobile-client/src/hooks/use-discard-sheet.ts
+++ b/mobile-client/src/hooks/use-discard-sheet.ts
@@ -1,0 +1,50 @@
+/**
+ * useDiscardSheet — Story 2.7 (UX-DR12)
+ *
+ * Shows a destructive confirmation bottom-sheet before discarding a session.
+ * - iOS  : native ActionSheet (slides up from the bottom)
+ * - Android : Alert dialog (no native bottom-sheet equivalent)
+ *
+ * Usage:
+ *   const showDiscard = useDiscardSheet();
+ *   showDiscard({ title: '...', message: '...', confirmLabel: '...', onConfirm: fn });
+ */
+import { useCallback } from 'react';
+import { Alert, Platform } from 'react-native';
+import { useActionSheet } from '@expo/react-native-action-sheet';
+
+interface DiscardOptions {
+  title: string;
+  message: string;
+  confirmLabel: string;
+  onConfirm: () => void;
+}
+
+export function useDiscardSheet() {
+  const { showActionSheetWithOptions } = useActionSheet();
+
+  return useCallback(
+    ({ title, message, confirmLabel, onConfirm }: DiscardOptions) => {
+      if (Platform.OS === 'ios') {
+        showActionSheetWithOptions(
+          {
+            title,
+            message,
+            options: [confirmLabel, 'Continuer'],
+            destructiveButtonIndex: 0,
+            cancelButtonIndex: 1,
+          },
+          (selectedIndex) => {
+            if (selectedIndex === 0) onConfirm();
+          },
+        );
+      } else {
+        Alert.alert(title, message, [
+          { text: 'Continuer', style: 'cancel' },
+          { text: confirmLabel, style: 'destructive', onPress: onConfirm },
+        ]);
+      }
+    },
+    [showActionSheetWithOptions],
+  );
+}


### PR DESCRIPTION
Replace Alert.alert with OS-native ActionSheet on iOS and Alert fallback on Android across all three sport screens. useDiscardSheet hook centralises the logic — 4 tests cover both platforms and confirm/cancel paths.